### PR TITLE
Fix Release candidate pytest invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - run: uv run ruff format --check .
       - run: uv run ruff check .
       - run: uv run mypy src
-      - run: uv run pytest -q
+      - run: uv run python -m pytest -q
       - run: uv build --out-dir dist
       - run: uvx --from twine twine check dist/*
       - run: python scripts/check_release_artifacts.py dist --version 2.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ uv lock --check
 uv run ruff format --check .
 uv run ruff check .
 uv run mypy src
-uv run pytest -q
+uv run python -m pytest -q
 uv run workbooklens demo --out .artifacts/demo
 uv build --out-dir dist
 uvx --from twine twine check dist/*

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ uv sync --locked
 uv run ruff format --check .
 uv run ruff check .
 uv run mypy src
-uv run pytest -q
+uv run python -m pytest -q
 uv build --out-dir dist
 uvx --from twine twine check dist/*
 python scripts/check_release_artifacts.py dist --version 2.0.0


### PR DESCRIPTION
## Summary

- Run the Release candidate test suite through `python -m pytest` so repository-local helper modules remain importable under pytest 9.
- Update README and CONTRIBUTING development commands to use the same reliable invocation.

## Root cause

The tag-triggered Release candidate used `uv run pytest -q`. With pytest 9.1.1, the console-script entry point did not put the repository root on `sys.path`, so `tests/unit/test_action_scan.py` could not import `scripts.action_scan`. Main CI already used `python -m pytest` and passed.

## Safety and compatibility

- [x] No workbook or application behavior changes.
- [x] No public JSON, CLI, Action, or plugin contract changes.
- [x] No generated environments, caches, credentials, or artifacts are committed.
- [x] The change only aligns Release validation and developer documentation with main CI.

## Verification

- `ruff format --check .`: passed
- `ruff check .`: passed
- `mypy src`: passed
- `python -m pytest -q`: 126 passed
- Coverage: 84.43% (required: 75%)

The failed tag run is [Release candidate #1](https://github.com/chenweixin123/workbooklens/actions/runs/32270226625). After merge, `v2.0.0` will be moved to the new main commit and the tag workflow rerun.