### PR TITLE
[codex] Release WorkbookLens 2.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: version
     attributes:
       label: WorkbookLens version or commit
-      placeholder: 2.0.0 or a commit SHA
+      placeholder: 2.1.0 or a commit SHA
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uv lock --check
       - run: uv build --out-dir dist
-      - run: uvx --from twine twine check dist/*
-      - run: python scripts/check_release_artifacts.py dist --version 2.0.0
+      - run: uvx --from twine twine check --strict dist/*
+      - run: python scripts/check_release_artifacts.py dist --version 2.1.0
       - uses: actions/upload-artifact@v7
         with:
           name: workbooklens-distributions
@@ -142,4 +142,3 @@ jobs:
           path: .action-fixtures
           fail-on: critical
           output: .action-reports
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,8 @@ jobs:
       - run: uv run mypy src
       - run: uv run python -m pytest -q
       - run: uv build --out-dir dist
-      - run: uvx --from twine twine check dist/*
-      - run: python scripts/check_release_artifacts.py dist --version 2.0.0
+      - run: uvx --from twine twine check --strict dist/*
+      - run: python scripts/check_release_artifacts.py dist --version 2.1.0
       - name: Create checksums
         run: sha256sum dist/* > SHA256SUMS
       - uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes are documented here. WorkbookLens follows Semantic Versioning.
 
+## [2.1.0] - 2026-08-20
+
+### Changed
+
+- Preserve repair safety for protected input cells and explicitly text-formatted cells by refusing
+  style-copy patches that would change their protection or text-storage semantics.
+- Restrict automatic numeric-text conversion to an explicit measure-header allowlist. Identifier
+  columns such as IDs, SKUs, account numbers, postal codes, and Chinese identifier fields, unknown
+  columns, grouped numeric strings, and explicitly text-formatted values are findings-only.
+  A separate numeric-text anomaly in an identifier column no longer prevents an otherwise safe
+  explicit-measure conversion on the same ordinary detail row.
+- Keep every merged-range cell, summary or subtotal row, protected worksheet, non-visible worksheet,
+  and hidden row or column out of automatic repair. Grouped hidden column spans are now recognized
+  across their complete range and represented accurately in snapshots.
+- Require formula and style repairs to establish stable detail-row context across all text columns
+  and peer visual styles. Secondary override labels, labels outside the inferred data rectangle,
+  intentionally highlighted rows, unique notes, and free-form-only row labels are review-only.
+- Require style-copy repairs to preserve number format, protection, quote-prefix, and pivot-button
+  semantics; protection-only differences are not reported as visual style anomalies.
+- Skip valid Chartsheet relationships during worksheet analysis and patching while preserving
+  Chartsheet, chart, drawing, and relationship parts byte-for-byte.
+- Exclude boundary totals and subtotals from formula-outlier replacement, report multiple isolated
+  formula/style anomalies without bulk auto-repair, and make all suspicious SUM-boundary findings
+  review-only because adjacency cannot prove inclusion semantics.
+
+### Security
+
+- Recheck non-visible sheets, hidden rows, grouped hidden columns, protected sheets, and semantic
+  style fields in the low-level OOXML patch preconditions.
+- Reject hidden column spans outside Excel's A:XFD limit before expanding snapshot metadata.
+
+### Compatibility
+
+- JSON schemas and rule IDs remain unchanged from 2.0.0.
+- `PatchKind.EXTEND_SUM` remains in the serialized enum for compatibility, but 2.1 does not generate
+  it as a canonical automatic repair.
+- Serialized patch plans continue to be revalidated against a fresh canonical scan before repair
+  authority is granted.
+
 ## [2.0.0] - 2026-08-19
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ uv run mypy src
 uv run python -m pytest -q
 uv run workbooklens demo --out .artifacts/demo
 uv build --out-dir dist
-uvx --from twine twine check dist/*
-python scripts/check_release_artifacts.py dist --version 2.0.0
+uvx --from twine twine check --strict dist/*
+python scripts/check_release_artifacts.py dist --version 2.1.0
 ~~~
 
 Review for unsafe ZIP handling, unbounded memory/ranges, inaccurate documentation, source rewrites,

--- a/README.md
+++ b/README.md
@@ -3,16 +3,32 @@
 **Deterministic linting, regression testing, semantic diffing, and conservative repair for
 Excel workbooks.**
 
-WorkbookLens 2.0 works locally without Microsoft Excel, LibreOffice, an AI key, or a cloud service.
+WorkbookLens 2.1 works locally without Microsoft Excel, LibreOffice, an AI key, or a cloud service.
 It does not calculate formulas, execute VBA, open embedded objects, or fetch external links.
 .xlsx files support scan, test, diff, and safe-copy repair; .xlsm files remain read-only.
 
-> **Release status:** this checkout is the 2.0.0 release candidate. Until
-> [PyPI](https://pypi.org/project/workbooklens/) shows version 2.0.0 and the repository contains the
-> v2.0.0 tag, use the source-install instructions below. Do not assume pipx or uvx can install an
-> unpublished package.
+> **Release status:** GitHub Releases are authoritative for source archives and attached artifacts.
+> Version 2.1.0 may not be published to [PyPI](https://pypi.org/project/workbooklens/); use the
+> source-install instructions below unless PyPI explicitly lists that version. Do not assume pipx
+> or uvx can install a GitHub-only release.
 
-## What is new in 2.0
+## What is new in 2.1
+
+- Chartsheet workbooks scan and repair their ordinary worksheets without losing chart parts.
+- Numeric text is auto-converted only under an explicit measure header such as Amount, Price,
+  Units, Balance, 金额, or 数量. Unknown columns, identifiers, and explicitly text-formatted cells
+  remain review-only.
+- Merged ranges, summary/subtotal rows, non-visible worksheets, hidden rows or columns (including
+  grouped columns), and protected worksheets remain review-only for automatic repair.
+- Formula and style patches also require stable detail-row evidence. Unknown summary labels,
+  secondary override/adjustment labels, intentionally highlighted rows, and free-form-only row
+  labels are findings-only when ordinary row semantics cannot be established conservatively.
+- Style repair preserves number format, protection, quote-prefix, and pivot-button semantics.
+  Multiple isolated anomalies are reported without bulk auto-repair.
+- Suspicious SUM boundaries now report the candidate formula without an automatic patch because
+  adjacency alone cannot prove that a tax, adjustment, subtotal, or statistic belongs in the SUM.
+
+## What was new in 2.0
 
 - Baseline-aware scans accept a source-scoped findings.json or an aggregate baseline manifest.
 - The --new-only gate uses stable rule/location identities; evidence changes are tracked separately.
@@ -47,11 +63,11 @@ uv run workbooklens --version
 uv run workbooklens demo --out .artifacts/demo
 ~~~
 
-After 2.0.0 is published, isolated installation is:
+If PyPI lists version 2.1.0, isolated installation is:
 
 ~~~bash
-uvx --from workbooklens==2.0.0 workbooklens --help
-pipx install workbooklens==2.0.0
+uvx --from workbooklens==2.1.0 workbooklens --help
+pipx install workbooklens==2.1.0
 ~~~
 
 ## Core workflows
@@ -126,7 +142,7 @@ confidentiality as the input workbook.
 
 ## GitHub Action
 
-After the v2.0.0 tag exists:
+After the v2.1.0 tag exists:
 
 ~~~yaml
 permissions:
@@ -138,7 +154,7 @@ steps:
     with:
       fetch-depth: 0
 
-  - uses: chenweixin123/workbooklens@v2.0.0
+  - uses: chenweixin123/workbooklens@v2.1.0
     with:
       mode: scan
       path: workbooks
@@ -152,7 +168,7 @@ steps:
 Assertion mode requires config and deliberately rejects baseline/new-only:
 
 ~~~yaml
-- uses: chenweixin123/workbooklens@v2.0.0
+- uses: chenweixin123/workbooklens@v2.1.0
   with:
     mode: test
     path: workbooks
@@ -170,6 +186,17 @@ by the Action.
 Repair plans bind every operation to the complete source SHA-256 and a target-cell fingerprint.
 Before writing, the engine rescans the source and requires the serialized plan to match the canonical
 plan field-for-field; only canonical operations marked safe with confidence at least 0.95 execute.
+Automatic operations are withheld for merged targets, summary rows, non-visible sheets, hidden rows
+or columns, and protected worksheets. The low-level patcher independently rechecks protection and
+visibility so an edited or stale plan cannot bypass the scanner's safety boundary. Numeric conversion
+requires an explicit measure-column signal; an unknown header is not treated as permission to change
+stored text into a number. Style-copy operations must preserve number-format, cell-protection,
+quote-prefix, and pivot-button semantics.
+
+For formula and style operations, the target row must also agree with stable peer-row text and visual
+patterns. A secondary adjustment label, a unique note, a whole-row highlight, or only free-form labels
+without a dominant template causes automatic repair to be withheld.
+
 The engine writes a new OOXML package directly, verifies the exact changed-part allowlist, reopens
 the result, rescans it, and removes partial output after validation failure. Formula edits remove
 stale caches and request Excel recalculation; WorkbookLens never claims to have calculated the result.
@@ -188,8 +215,13 @@ workbook to a public issue.
 
 - No Excel calculation engine, VBA execution, external-link fetching, or embedded-object opening.
 - No automatic repair for shared, array, data-table, spilled, or dynamic-array formulas.
+- Suspicious SUM boundaries are findings-only; the expected formula is evidence for human review,
+  not proof that the adjacent row belongs in the aggregate.
 - Structured references can be scanned but are not translated for repair.
 - Region inference is conservative and can miss sparse or unusually formatted tables.
+- Rule and region detection are deterministic heuristics. Passing a scan does not prove that every
+  real-world workbook error has been found, and a finding does not by itself prove the proposed
+  business meaning.
 - .xls, .xlsb, .ods, and Google Sheets are unsupported.
 - OOXML is extensible; preservation tests reduce risk but do not prove compatibility with every
   vendor extension.
@@ -203,8 +235,8 @@ uv run ruff check .
 uv run mypy src
 uv run python -m pytest -q
 uv build --out-dir dist
-uvx --from twine twine check dist/*
-python scripts/check_release_artifacts.py dist --version 2.0.0
+uvx --from twine twine check --strict dist/*
+python scripts/check_release_artifacts.py dist --version 2.1.0
 ~~~
 
 See [CONTRIBUTING.md](CONTRIBUTING.md), [the architecture guide](docs/architecture.md),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,15 +32,15 @@ reproducer.
 
 | Version | Security support |
 |---|---|
-| 2.0.x | Supported |
-| Earlier than 2.0 | Upgrade required |
+| 2.1.x | Supported |
+| 2.0.x and earlier | Upgrade required |
 
 Security fixes land on main and are included in the next supported patch release. A GitHub
 Security Advisory may remain private until users have an upgrade path.
 
 ## Security model
 
-WorkbookLens 2.0 does not execute formulas, VBA, embedded objects, or external links. It rejects
+WorkbookLens 2.1 does not execute formulas, VBA, embedded objects, or external links. It rejects
 packages that exceed entry, compressed/uncompressed size, compression-ratio, member-path,
 relationship, or XML limits. DTDs and entities are forbidden. .xlsm remains read-only.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -23,7 +23,7 @@
 - [ ] Adversarial ZIP/XML/relationship and web-limit tests pass.
 - [ ] CodeQL, dependency review, and locked-runtime vulnerability audit pass.
 - [ ] GitHub Actions and dependencies have reviewed updates.
-- [ ] uv build --out-dir dist and twine check dist/* pass.
+- [ ] uv build --out-dir dist and twine check --strict dist/* pass.
 - [ ] scripts/check_release_artifacts.py passes for the release version.
 - [ ] Unpacked wheel/sdist contain no environment, cache, bytecode, environment file, credential,
   private key, or unexpected top-level path.
@@ -36,12 +36,14 @@
 
 ## Release candidate and publication
 
-- [ ] Push v2.0.0; the release-candidate workflow validates the tag, builds distributions,
+- [ ] Push v2.1.0; the release-candidate workflow validates the tag, builds distributions,
   generates SHA256SUMS, and uploads workflow artifacts.
 - [ ] Inspect the downloaded artifacts before external publication.
-- [ ] Configure the GitHub pypi environment and PyPI trusted publisher for
-  chenweixin123/workbooklens before enabling online publication.
-- [ ] Publish only from the validated tag using OIDC trusted publishing; do not add a long-lived
-  PyPI token.
-- [ ] Attach wheel, sdist, checksums, and provenance attestation to the GitHub Release.
-- [ ] Verify the PyPI page, uvx installation, and pipx installation for version 2.0.0.
+- [ ] Record whether the release is GitHub-only or also publishes to PyPI.
+- [ ] Attach the validated wheel, sdist, and checksums to the GitHub Release. Attach a provenance
+  attestation only when the release workflow produces one.
+- [ ] If publishing to PyPI, configure the GitHub pypi environment and trusted publisher for
+  chenweixin123/workbooklens, then publish only from the validated tag using OIDC; do not add a
+  long-lived PyPI token.
+- [ ] If publishing to PyPI, verify the project page, uvx installation, and pipx installation for
+  version 2.1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "workbooklens"
-version = "2.0.0"
+version = "2.1.0"
 description = "Local-first linting, testing, semantic diffing, and safe repair for Excel workbooks"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/workbooklens/__init__.py
+++ b/src/workbooklens/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/src/workbooklens/demo/workflow.py
+++ b/src/workbooklens/demo/workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -88,7 +89,6 @@ def generate_demo_workbook(path: Path) -> None:
         sales[f"C{row}"].number_format = "$#,##0.00"
         sales[f"D{row}"].number_format = "$#,##0.00"
         sales[f"E{row}"].number_format = "$#,##0.00"
-    sales["C17"].number_format = "0.0%"  # One style/number-format outlier.
     sales.row_dimensions[20].hidden = True
     validation = DataValidation(type="list", formula1='"Open,Paid,Void"', allow_blank=False)
     sales.add_data_validation(validation)
@@ -131,6 +131,10 @@ def generate_demo_workbook(path: Path) -> None:
     hidden.sheet_state = "hidden"
     workbook.defined_names.add(DefinedName("BrokenName", attr_text="#REF!"))
     _style_cells(workbook)
+    sales["D8"]._style = copy(sales["D7"]._style)  # Pure content gap; no visual leave-blank signal.
+    sales["C17"].font = Font(
+        name="Arial", size=10, italic=True, color="FF9C0006"
+    )  # One visual-only style outlier; numeric semantics remain unchanged.
     # openpyxl is intentionally used only to create the demo input, never to save a repair.
     workbook.save(path)
     workbook.close()

--- a/src/workbooklens/ooxml/formula_ranges.py
+++ b/src/workbooklens/ooxml/formula_ranges.py
@@ -40,22 +40,16 @@ def _sheet_parts(archive: zipfile.ZipFile, limits: PackageLimits) -> dict[str, s
     relationships_root = parse_xml_part(
         _bounded_part(archive, relationships_part, limits), relationships_part
     )
-    relationships: dict[str, str] = {}
+    relationships: dict[str, tuple[str, str]] = {}
     for relationship in relationships_root:
         if etree.QName(relationship).localname != "Relationship":
             continue
         relationship_id = relationship.get("Id")
         target = relationship.get("Target")
         relationship_type = relationship.get("Type", "")
-        if not relationship_id or not target or not relationship_type.endswith("/worksheet"):
+        if not relationship_id or not target:
             continue
-        candidate = target.lstrip("/") if target.startswith("/") else posixpath.join("xl", target)
-        normalized = posixpath.normpath(candidate)
-        if normalized.startswith("../") or normalized in {"", ".", ".."}:
-            raise UnsafeWorkbookError(
-                f"Worksheet relationship target escapes the package: {target!r}"
-            )
-        relationships[relationship_id] = normalized
+        relationships[relationship_id] = (relationship_type, target)
     result: dict[str, str] = {}
     for sheet in workbook_root.iter():
         if etree.QName(sheet).localname != "sheet":
@@ -74,7 +68,20 @@ def _sheet_parts(archive: zipfile.ZipFile, limits: PackageLimits) -> dict[str, s
         )
         if not name or not relationship_id or relationship_id not in relationships:
             raise UnsafeWorkbookError("Workbook contains a malformed worksheet relationship")
-        result[name] = relationships[relationship_id]
+        relationship_type, target = relationships[relationship_id]
+        if relationship_type.endswith("/chartsheet"):
+            continue
+        if not relationship_type.endswith("/worksheet"):
+            raise UnsafeWorkbookError(
+                f"Workbook contains an unsupported sheet relationship type: {relationship_type!r}"
+            )
+        candidate = target.lstrip("/") if target.startswith("/") else posixpath.join("xl", target)
+        normalized = posixpath.normpath(candidate)
+        if normalized.startswith("../") or normalized in {"", ".", ".."}:
+            raise UnsafeWorkbookError(
+                f"Worksheet relationship target escapes the package: {target!r}"
+            )
+        result[name] = normalized
     return result
 
 

--- a/src/workbooklens/ooxml/safety.py
+++ b/src/workbooklens/ooxml/safety.py
@@ -235,7 +235,7 @@ def inspect_package(path: Path, limits: PackageLimits | None = None) -> PackageI
         raise UsageError(f"Workbook does not exist or is not a file: {path}")
     suffix = resolved.suffix.lower()
     if suffix not in {".xlsx", ".xlsm"}:
-        raise UsageError("WorkbookLens 2.0 accepts only .xlsx and read-only .xlsm inputs")
+        raise UsageError("WorkbookLens 2.1 accepts only .xlsx and read-only .xlsm inputs")
     file_size = resolved.stat().st_size
     if file_size > active_limits.max_file_bytes:
         raise UnsafeWorkbookError(

--- a/src/workbooklens/repair/ooxml_patch.py
+++ b/src/workbooklens/repair/ooxml_patch.py
@@ -26,6 +26,7 @@ from workbooklens.models import PackageChange, PatchKind, PatchOperation, PatchP
 from workbooklens.ooxml.safety import PackageLimits, inspect_package, parse_xml_part
 from workbooklens.snapshot import cell_fingerprint, load_for_analysis
 from workbooklens.utils import sha256_file
+from workbooklens.worksheet_state import is_column_hidden
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,15 +77,15 @@ def _sheet_parts(archive: zipfile.ZipFile) -> dict[str, str]:
     if rels_name not in archive.namelist():
         raise PatchValidationError("Workbook relationships part is missing")
     rels_root = parse_xml_part(archive.read(rels_name), rels_name)
-    relationships: dict[str, str] = {}
+    relationships: dict[str, tuple[str, str]] = {}
     for relationship in rels_root:
         if etree.QName(relationship).localname != "Relationship":
             continue
         relationship_id = relationship.get("Id")
         target = relationship.get("Target")
         relationship_type = relationship.get("Type", "")
-        if relationship_id and target and relationship_type.endswith("/worksheet"):
-            relationships[relationship_id] = _resolve_part("xl/workbook.xml", target)
+        if relationship_id and target:
+            relationships[relationship_id] = (relationship_type, target)
     result: dict[str, str] = {}
     for sheet in workbook_root.iter():
         if etree.QName(sheet).localname != "sheet":
@@ -103,7 +104,14 @@ def _sheet_parts(archive: zipfile.ZipFile) -> dict[str, str]:
         )
         if not name or not relationship_id or relationship_id not in relationships:
             raise PatchValidationError("Workbook contains a sheet with a malformed relationship")
-        result[name] = relationships[relationship_id]
+        relationship_type, target = relationships[relationship_id]
+        if relationship_type.endswith("/chartsheet"):
+            continue
+        if not relationship_type.endswith("/worksheet"):
+            raise PatchValidationError(
+                f"Workbook contains an unsupported sheet relationship type: {relationship_type!r}"
+            )
+        result[name] = _resolve_part("xl/workbook.xml", target)
     return result
 
 
@@ -202,6 +210,23 @@ def _assert_not_in_advanced_formula_range(root: etree._Element, coordinate: str)
             )
 
 
+def _assert_not_in_merged_range(root: etree._Element, coordinate: str) -> None:
+    for element in root.iter():
+        if etree.QName(element).localname != "mergeCell":
+            continue
+        reference = element.get("ref")
+        if not reference:
+            continue
+        try:
+            merged = CellRange(reference)
+        except ValueError as exc:
+            raise PatchValidationError(f"Invalid merged range {reference!r}") from exc
+        if coordinate in merged:
+            raise PatchValidationError(
+                f"target {coordinate} intersects merged range {reference}; automatic patches are refused"
+            )
+
+
 def _remove_value_children(cell: etree._Element) -> None:
     for child in list(cell):
         if etree.QName(child).localname in {"f", "v", "is"}:
@@ -214,7 +239,7 @@ def _set_formula(cell: etree._Element, formula: str) -> None:
     features = analyze_formula(formula)
     if features.external_references or features.unsupported_reason:
         raise PatchValidationError(
-            "External, structured, dynamic, spilled, or advanced formulas are not patchable in 2.0"
+            "External, structured, dynamic, spilled, or advanced formulas are not patchable"
         )
     namespace = _element_namespace(cell)
     _remove_value_children(cell)
@@ -311,10 +336,12 @@ def _verify_preconditions(
         )
     workbook = load_for_analysis(source, limits)
     try:
+        worksheets = {worksheet.title: worksheet for worksheet in workbook.worksheets}
         for patch in selected:
-            if patch.sheet not in workbook.sheetnames:
-                raise StalePlanError(f"Patch sheet no longer exists: {patch.sheet!r}")
-            cell = workbook[patch.sheet][patch.cell]
+            worksheet = worksheets.get(patch.sheet)
+            if worksheet is None:
+                raise StalePlanError(f"Patch worksheet no longer exists: {patch.sheet!r}")
+            cell = worksheet[patch.cell]
             if not isinstance(cell, Cell):
                 raise StalePlanError(
                     f"Patch target is not a writable cell: {patch.sheet}!{patch.cell}"
@@ -324,6 +351,52 @@ def _verify_preconditions(
                 raise StalePlanError(
                     f"Cell precondition failed for {patch.sheet}!{patch.cell}; plan is stale"
                 )
+            if worksheet.protection.sheet:
+                raise PatchValidationError(
+                    f"Patch target is on protected worksheet {patch.sheet!r}; unprotect it before repair"
+                )
+            if worksheet.sheet_state != "visible":
+                raise PatchValidationError(
+                    f"Patch target is on non-visible worksheet {patch.sheet!r}; unhide it before repair"
+                )
+            row_dimension = worksheet.row_dimensions.get(cell.row)
+            if row_dimension is not None and row_dimension.hidden:
+                raise PatchValidationError(
+                    f"Patch target is on hidden row {patch.sheet}!{cell.row}; unhide it before repair"
+                )
+            if is_column_hidden(worksheet, cell.column):
+                raise PatchValidationError(
+                    f"Patch target is in a hidden column at {patch.sheet}!{patch.cell}; "
+                    "unhide it before repair"
+                )
+            if patch.kind == PatchKind.COPY_STYLE:
+                if not patch.source_cell:
+                    raise PatchValidationError(f"Style patch {patch.id} has no source cell")
+                source_cell = worksheet[patch.source_cell]
+                if not isinstance(source_cell, Cell):
+                    raise PatchValidationError(
+                        f"Style patch source is not a writable cell: "
+                        f"{patch.sheet}!{patch.source_cell}"
+                    )
+                if (
+                    cell.protection.locked != source_cell.protection.locked
+                    or cell.protection.hidden != source_cell.protection.hidden
+                ):
+                    raise PatchValidationError(
+                        f"Style patch {patch.id} would change cell protection semantics"
+                    )
+                if cell.number_format != source_cell.number_format:
+                    raise PatchValidationError(
+                        f"Style patch {patch.id} would change number-format semantics"
+                    )
+                if cell.quotePrefix != source_cell.quotePrefix:
+                    raise PatchValidationError(
+                        f"Style patch {patch.id} would change quote-prefix semantics"
+                    )
+                if cell.pivotButton != source_cell.pivotButton:
+                    raise PatchValidationError(
+                        f"Style patch {patch.id} would change pivot-button semantics"
+                    )
     finally:
         workbook.close()
 
@@ -359,9 +432,20 @@ def _select_patches(
         ]
         if unsafe:
             raise UsageError(
-                "WorkbookLens 2.0 refuses patches below the safe 0.95 threshold: "
+                "WorkbookLens 2.1 refuses patches below the safe 0.95 threshold: "
                 + ", ".join(unsafe)
             )
+    domains: dict[tuple[str, str, str], list[str]] = {}
+    for patch in selected:
+        domain = "style" if patch.kind == PatchKind.COPY_STYLE else "content"
+        domains.setdefault((patch.sheet, patch.cell, domain), []).append(patch.id)
+    conflicts = [
+        f"{sheet}!{cell} ({domain}: {', '.join(sorted(patch_ids))})"
+        for (sheet, cell, domain), patch_ids in sorted(domains.items())
+        if len(patch_ids) > 1
+    ]
+    if conflicts:
+        raise UsageError("Conflicting patches target the same cell: " + "; ".join(conflicts))
     return selected
 
 
@@ -404,6 +488,7 @@ def _apply_to_parts(
         root = parse_xml_part(archive.read(part), part)
         for patch in patches:
             _assert_not_in_advanced_formula_range(root, patch.cell)
+            _assert_not_in_merged_range(root, patch.cell)
             target = _find_or_create_cell(root, patch.cell)
             _assert_simple_formula_cell(target, f"target {patch.sheet}!{patch.cell}")
             source_element = None
@@ -536,8 +621,14 @@ def _publish_without_overwrite(temporary: Path, output: Path, expected_hash: str
 def _validate_semantics(output: Path, selected: list[PatchOperation]) -> None:
     workbook = load_workbook(output, read_only=False, data_only=False, keep_links=False)
     try:
+        worksheets = {worksheet.title: worksheet for worksheet in workbook.worksheets}
         for patch in selected:
-            cell = workbook[patch.sheet][patch.cell]
+            worksheet = worksheets.get(patch.sheet)
+            if worksheet is None:
+                raise PatchValidationError(
+                    f"Patched worksheet is missing from output: {patch.sheet!r}"
+                )
+            cell = worksheet[patch.cell]
             if (
                 patch.kind
                 in {

--- a/src/workbooklens/rules/builtin.py
+++ b/src/workbooklens/rules/builtin.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import math
 import re
+import unicodedata
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Sequence
+from copy import copy
 from decimal import Decimal, InvalidOperation
+from itertools import pairwise
 from typing import Any, cast
 
-from openpyxl.cell.cell import Cell
+from openpyxl.cell.cell import Cell, MergedCell
 from openpyxl.utils.cell import (
     get_column_letter,
     range_boundaries,
@@ -36,6 +39,7 @@ from workbooklens.models import (
 from workbooklens.rules.base import RuleContext, RuleResult, WorkbookRule
 from workbooklens.snapshot import cell_fingerprint
 from workbooklens.utils import stable_id
+from workbooklens.worksheet_state import hidden_column_spans, is_column_hidden
 
 EXCEL_ERRORS = {"#NULL!", "#DIV/0!", "#VALUE!", "#REF!", "#NAME?", "#NUM!", "#N/A"}
 SIMPLE_SUM_RE = re.compile(
@@ -43,6 +47,130 @@ SIMPLE_SUM_RE = re.compile(
     r"(?P<col1>\$?[A-Z]{1,3})(?P<start>\$?\d+):"
     r"(?P<col2>\$?[A-Z]{1,3})(?P<end>\$?\d+)\)$",
     re.IGNORECASE,
+)
+AGGREGATE_FUNCTION_RE = re.compile(
+    r"(?<![A-Z0-9_])(?:(?:_XLFN|_XLWS)\.)*(?:SUM|SUBTOTAL|AGGREGATE)\s*\(",
+    re.IGNORECASE,
+)
+SUMMARY_LABEL_RE = re.compile(
+    r"(?<![A-Z0-9_])(?:(?:grand|sub)[\s-]+total|subtotal|total|average|avg|mean|"
+    r"minimum|maximum|min|max|median|summary|ending[\s-]+balance|closing[\s-]+balance|"
+    r"net[\s-]+amount|adjustment|override|manual[\s-]+override)(?![A-Z0-9_])"
+    r"|(?:合计|总计|小计|汇总|平均|均值|最大|最小|中位数|总金额|累计|净额|期末余额|"
+    r"期初余额|调整项|调整|手工覆盖|人工覆盖)",
+    re.IGNORECASE,
+)
+DIRECT_MEASURE_HEADER_TOKENS = {
+    "amount",
+    "balance",
+    "cost",
+    "count",
+    "duration",
+    "hours",
+    "length",
+    "limit",
+    "margin",
+    "measure",
+    "price",
+    "quantity",
+    "rate",
+    "revenue",
+    "score",
+    "tax",
+    "total",
+    "units",
+    "value",
+    "volume",
+    "weight",
+}
+MEASURE_HEADER_MARKERS = (
+    "金额",
+    "余额",
+    "价格",
+    "单价",
+    "成本",
+    "数量",
+    "数额",
+    "费用",
+    "税额",
+    "税率",
+    "收入",
+    "营收",
+    "时长",
+    "小时",
+    "长度",
+    "重量",
+    "比率",
+    "比例",
+    "分数",
+    "得分",
+    "上限",
+    "限额",
+    "额度",
+    "容量",
+    "体积",
+)
+DIRECT_IDENTIFIER_HEADER_TOKENS = {
+    "code",
+    "id",
+    "identifier",
+    "iban",
+    "imei",
+    "imsi",
+    "isbn",
+    "key",
+    "ssn",
+    "sku",
+    "vin",
+    "zip",
+}
+IDENTIFIER_NUMBER_PREFIXES = {
+    "account",
+    "bank",
+    "card",
+    "claim",
+    "contract",
+    "credit",
+    "customer",
+    "employee",
+    "invoice",
+    "license",
+    "member",
+    "mobile",
+    "order",
+    "passport",
+    "phone",
+    "policy",
+    "product",
+    "record",
+    "reference",
+    "routing",
+    "security",
+    "serial",
+    "social",
+    "telephone",
+    "vendor",
+}
+IDENTIFIER_HEADER_MARKERS = (
+    "标识",
+    "编号",
+    "编码",
+    "代码",
+    "号码",
+    "账号",
+    "帐号",
+    "手机号",
+    "电话",
+    "身份证",
+    "证件",
+    "银行卡",
+    "卡号",
+    "社保",
+    "护照",
+    "单号",
+    "工号",
+    "学号",
+    "邮编",
 )
 
 
@@ -160,6 +288,359 @@ def _band_has_unsupported_formula(context: RuleContext, sheet: str, cells: Seque
     return any(_in_unsupported_formula_range(context, sheet, cell.coordinate) for cell in cells)
 
 
+def _is_aggregate_formula(value: Any) -> bool:
+    if not isinstance(value, str) or not value.startswith("="):
+        return False
+    output: list[str] = []
+    index = 0
+    inside_string = False
+    while index < len(value):
+        character = value[index]
+        if character == '"':
+            if inside_string and index + 1 < len(value) and value[index + 1] == '"':
+                output.extend((" ", " "))
+                index += 2
+                continue
+            inside_string = not inside_string
+            output.append(" ")
+        else:
+            output.append(" " if inside_string else character)
+        index += 1
+    return AGGREGATE_FUNCTION_RE.search("".join(output)) is not None
+
+
+def _is_band_boundary(cell: Cell, band: Region) -> bool:
+    if band.kind == "formula_row":
+        return cell.column in {band.min_column, band.max_column}
+    return cell.row in {band.min_row, band.max_row}
+
+
+def _is_boundary_aggregate(cell: Cell, band: Region) -> bool:
+    if not isinstance(cell.value, str) or not cell.value.startswith("="):
+        return False
+    features = analyze_formula(cell.value)
+    references: list[tuple[int, int, int, int]] = []
+    for reference in features.references:
+        if "!" in reference:
+            continue
+        try:
+            boundaries = range_boundaries(reference.replace("$", ""))
+        except ValueError:
+            continue
+        if not all(isinstance(boundary, int) for boundary in boundaries):
+            continue
+        references.append(cast(tuple[int, int, int, int], boundaries))
+    if not references:
+        return False
+    cell_row = int(cell.row)
+    cell_column = int(cell.column)
+    expected: tuple[int, int, int, int] | None
+    if band.kind == "formula_row":
+        expected = (
+            (band.min_column, cell_row, cell_column - 1, cell_row)
+            if cell_column == band.max_column
+            else (cell_column + 1, cell_row, band.max_column, cell_row)
+            if cell_column == band.min_column
+            else None
+        )
+    else:
+        expected = (
+            (cell_column, band.min_row, cell_column, cell_row - 1)
+            if cell_row == band.max_row
+            else (cell_column, cell_row + 1, cell_column, band.max_row)
+            if cell_row == band.min_row
+            else None
+        )
+    return expected is not None and expected in references
+
+
+def _is_merged_non_anchor(worksheet: Worksheet, coordinate: str) -> bool:
+    for merged in worksheet.merged_cells.ranges:
+        if coordinate not in merged:
+            continue
+        anchor = f"{get_column_letter(merged.min_col)}{merged.min_row}"
+        return coordinate != anchor
+    return False
+
+
+def _is_in_merged_range(worksheet: Worksheet, coordinate: str) -> bool:
+    return any(coordinate in merged for merged in worksheet.merged_cells.ranges)
+
+
+def _is_hidden_cell(worksheet: Worksheet, cell: Cell | MergedCell) -> bool:
+    row = cell.row
+    column = cell.column
+    if worksheet.sheet_state != "visible" or row is None or column is None:
+        return True
+    row_dimension = worksheet.row_dimensions.get(row)
+    return bool(
+        (row_dimension is not None and row_dimension.hidden) or is_column_hidden(worksheet, column)
+    )
+
+
+def _is_protected_target(worksheet: Worksheet) -> bool:
+    return bool(worksheet.protection.sheet)
+
+
+def _looks_like_identifier_header(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.strip().lower()
+    if not lowered:
+        return False
+    if any(marker in lowered for marker in IDENTIFIER_HEADER_MARKERS):
+        return True
+    tokens = [token for token in re.split(r"[^a-z0-9]+", lowered) if token]
+    if any(token in DIRECT_IDENTIFIER_HEADER_TOKENS for token in tokens):
+        return True
+    number_markers = {"number", "no", "num"}
+    return bool(number_markers.intersection(tokens)) and any(
+        token in IDENTIFIER_NUMBER_PREFIXES for token in tokens
+    )
+
+
+def _looks_like_measure_header(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.strip().lower()
+    if not lowered:
+        return False
+    if any(marker in lowered for marker in MEASURE_HEADER_MARKERS):
+        return True
+    tokens = [token for token in re.split(r"[^a-z0-9]+", lowered) if token]
+    return any(token in DIRECT_MEASURE_HEADER_TOKENS for token in tokens)
+
+
+def _band_position(cell: Cell, band: Region) -> int:
+    return cell.column if band.kind == "formula_row" else cell.row
+
+
+def _isolated_outliers(cells: Sequence[Cell], band: Region) -> bool:
+    positions = sorted(_band_position(cell, band) for cell in cells)
+    return all(right - left > 1 for left, right in pairwise(positions))
+
+
+def _same_data_region(context: RuleContext, worksheet: Worksheet, *cells: Cell) -> bool:
+    return any(
+        all(
+            region.min_row <= cell.row <= region.max_row
+            and region.min_column <= cell.column <= region.max_column
+            for cell in cells
+        )
+        for region in context.data_regions.get(worksheet.title, ())
+    )
+
+
+def _same_protection(left: Cell, right: Cell) -> bool:
+    return bool(
+        left.protection.locked == right.protection.locked
+        and left.protection.hidden == right.protection.hidden
+    )
+
+
+def _style_copy_preserves_semantics(target: Cell, source: Cell) -> bool:
+    return (
+        _same_protection(target, source)
+        and target.number_format == source.number_format
+        and target.quotePrefix == source.quotePrefix
+        and target.pivotButton == source.pivotButton
+    )
+
+
+def _visual_style_key(cell: Cell) -> tuple[Any, ...]:
+    """Group visually equivalent cells without treating protection flags as decoration."""
+
+    return (
+        copy(cell.font),
+        copy(cell.fill),
+        copy(cell.border),
+        copy(cell.alignment),
+        cell.number_format,
+    )
+
+
+def _row_has_summary_semantics(
+    worksheet: Worksheet, row: int, region: Region | None = None
+) -> bool:
+    cells = (
+        (
+            _cell(worksheet, row, column)
+            for column in range(region.min_column, region.max_column + 1)
+        )
+        if region is not None
+        else (
+            cell for cell in worksheet._cells.values() if isinstance(cell, Cell) and cell.row == row
+        )
+    )
+    for cell in cells:
+        value = cell.value
+        if _is_aggregate_formula(value):
+            return True
+        if isinstance(value, str) and SUMMARY_LABEL_RE.search(value.strip()):
+            return True
+    return False
+
+
+def _label_template(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).strip().casefold()
+    normalized = re.sub(r"\d+", "<n>", normalized)
+    return re.sub(r"\s+", " ", normalized)
+
+
+def _containing_data_region(
+    context: RuleContext, worksheet: Worksheet, cell: Cell | MergedCell
+) -> Region | None:
+    if cell.row is None or cell.column is None:
+        return None
+    candidates = [
+        region
+        for region in context.data_regions.get(worksheet.title, ())
+        if region.min_row <= cell.row <= region.max_row
+        and region.min_column <= cell.column <= region.max_column
+    ]
+    return min(
+        candidates,
+        key=lambda region: (
+            (region.max_row - region.min_row + 1) * (region.max_column - region.min_column + 1),
+            region.min_row,
+            region.min_column,
+        ),
+        default=None,
+    )
+
+
+def _row_label_matches_peer_template(
+    context: RuleContext,
+    worksheet: Worksheet,
+    cell: Cell | MergedCell,
+    region: Region | None = None,
+    *,
+    include_target: bool = False,
+    ignore_numeric_text: bool = False,
+    require_stable: bool = True,
+) -> bool:
+    """Require a stable record-label template when a text row label exists."""
+
+    if cell.row is None or cell.column is None:
+        return False
+    cell_row = cell.row
+    cell_column = cell.column
+    active_region = region or _containing_data_region(context, worksheet, cell)
+    label_cells = [
+        peer
+        for peer in worksheet._cells.values()
+        if isinstance(peer, Cell)
+        and peer.row == cell_row
+        and peer.column != cell_column
+        and peer.data_type != "f"
+        and isinstance(peer.value, str)
+        and peer.value.strip()
+        and not (ignore_numeric_text and _numeric_text(peer.value) is not None)
+    ]
+    if (
+        include_target
+        and isinstance(cell, Cell)
+        and isinstance(cell.value, str)
+        and cell.value.strip()
+    ):
+        label_cells.append(cell)
+    if not label_cells:
+        return True
+    if active_region is not None:
+        min_row = active_region.min_row + 1
+        max_row = active_region.max_row
+    else:
+        min_row = max(1, cell_row - 10)
+        max_row = cell_row + 10
+    stable_evidence = False
+    for label_cell in sorted(label_cells, key=lambda peer: peer.column):
+        label = cast(str, label_cell.value).strip()
+        if SUMMARY_LABEL_RE.search(label):
+            return False
+        template = _label_template(label)
+        peers = sorted(
+            (
+                peer
+                for peer in worksheet._cells.values()
+                if isinstance(peer, Cell)
+                and peer.column == label_cell.column
+                and min_row <= peer.row <= max_row
+                and peer.row != cell_row
+                and peer.data_type != "f"
+                and isinstance(peer.value, str)
+                and peer.value.strip()
+            ),
+            key=lambda peer: (abs(peer.row - cell_row), peer.row),
+        )[:8]
+        if not peers:
+            return False
+        counts = Counter(_label_template(cast(str, peer.value)) for peer in peers)
+        consensus, count = counts.most_common(1)[0]
+        if count >= 3 and count / len(peers) >= 0.75:
+            stable_evidence = True
+            if template != consensus:
+                return False
+    return stable_evidence or not require_stable
+
+
+def _row_visual_style_matches_peer_consensus(
+    context: RuleContext,
+    worksheet: Worksheet,
+    cell: Cell | MergedCell,
+    region: Region | None = None,
+    *,
+    include_target: bool = False,
+) -> bool:
+    """Reject auto-repair when another cell proves the row is intentionally highlighted."""
+
+    if cell.row is None or cell.column is None:
+        return False
+    cell_row = cell.row
+    cell_column = cell.column
+    active_region = region or _containing_data_region(context, worksheet, cell)
+    if active_region is not None:
+        min_row = active_region.min_row + 1
+        max_row = active_region.max_row
+        min_column = active_region.min_column
+        max_column = active_region.max_column
+    else:
+        min_row = max(1, cell_row - 10)
+        max_row = cell_row + 10
+        min_column = 1
+        max_column = worksheet.max_column
+    row_cells = [
+        peer
+        for peer in worksheet._cells.values()
+        if isinstance(peer, Cell)
+        and peer.row == cell_row
+        and min_column <= peer.column <= max_column
+        and peer.column != cell_column
+        and (peer.value is not None or peer.has_style)
+    ]
+    if include_target and isinstance(cell, Cell) and (cell.value is not None or cell.has_style):
+        row_cells.append(cell)
+    for row_cell in row_cells:
+        peers = sorted(
+            (
+                peer
+                for peer in worksheet._cells.values()
+                if isinstance(peer, Cell)
+                and peer.column == row_cell.column
+                and min_row <= peer.row <= max_row
+                and peer.row != cell_row
+                and (peer.value is not None or peer.has_style)
+            ),
+            key=lambda peer: (abs(peer.row - cell_row), peer.row),
+        )[:8]
+        if len(peers) < 3:
+            continue
+        counts = Counter(_visual_style_key(peer) for peer in peers)
+        consensus, count = counts.most_common(1)[0]
+        if count >= 3 and count / len(peers) >= 0.75 and _visual_style_key(row_cell) != consensus:
+            return False
+    return True
+
+
 def _translated_consensus(
     target: Cell, peers: Iterable[Cell], required_signature: str | None = None
 ) -> tuple[str, str] | None:
@@ -234,7 +715,11 @@ class FormulaPatternOutlierRule(WorkbookRule):
                 cells = _band_cells(worksheet, band)
                 if _band_has_unsupported_formula(context, worksheet.title, cells):
                     continue
-                formula_cells = [cell for cell in cells if cell.data_type == "f"]
+                formula_cells = [
+                    cell
+                    for cell in cells
+                    if cell.data_type == "f" and not _is_boundary_aggregate(cell, band)
+                ]
                 signature_by_cell = {
                     cell.coordinate: _formula_signature(cell) for cell in formula_cells
                 }
@@ -253,54 +738,92 @@ class FormulaPatternOutlierRule(WorkbookRule):
                     for cell in formula_cells
                     if signature_by_cell[cell.coordinate] != consensus
                 ]
-                if ratio < 0.8 or len(outliers) != 1:
+                if ratio < 0.8 or not outliers or not _isolated_outliers(outliers, band):
                     continue
-                cell = outliers[0]
-                if (worksheet.title, cell.coordinate) in seen:
-                    continue
-                seen.add((worksheet.title, cell.coordinate))
-                proposal = _translated_consensus(cell, formula_cells, consensus)
-                patches: list[PatchOperation] = []
-                if proposal is not None and ratio >= 0.95:
-                    formula, source = proposal
-                    patch = _make_patch(
-                        kind=PatchKind.SET_FORMULA,
-                        worksheet=worksheet,
-                        cell=cell,
-                        before=cell.value,
-                        after=formula,
-                        confidence=ratio,
-                        source_cell=source,
-                        description="Replace the one-off formula with the exact translated peer consensus.",
-                    )
-                    patches.append(patch)
-                    result.patches.append(patch)
                 peers = [
                     item.coordinate
                     for item in formula_cells
                     if signature_by_cell[item.coordinate] == consensus
                 ]
-                result.findings.append(
-                    _make_finding(
-                        context=context,
-                        rule_id=self.rule_id,
-                        title=self.title,
-                        explanation="One formula has a different relative-reference signature from a strong band consensus.",
-                        severity=Severity.WARNING,
-                        confidence=ratio,
-                        sheet=worksheet.title,
-                        location=cell.coordinate,
-                        evidence=Evidence(
-                            summary=f"{consensus_count} of {len(signatures)} formulas share one signature",
-                            observed=cell.value,
-                            expected=consensus,
-                            peers=peers[:12],
-                        ),
-                        expected="Copied formulas in this band have the same structural signature.",
-                        suggested_action="Compare the cell with the listed peers and review any proposed formula.",
-                        patches=patches,
+                for cell in outliers:
+                    if (worksheet.title, cell.coordinate) in seen:
+                        continue
+                    seen.add((worksheet.title, cell.coordinate))
+                    proposal = _translated_consensus(cell, formula_cells, consensus)
+                    patches: list[PatchOperation] = []
+                    aggregate_formula = _is_aggregate_formula(cell.value)
+                    row_semantics_safe = (
+                        not _row_has_summary_semantics(worksheet, cell.row)
+                        and _row_label_matches_peer_template(context, worksheet, cell)
+                        and _row_visual_style_matches_peer_consensus(
+                            context, worksheet, cell, include_target=True
+                        )
                     )
-                )
+                    if (
+                        proposal is not None
+                        and ratio >= 0.95
+                        and len(outliers) == 1
+                        and not aggregate_formula
+                        and not _is_band_boundary(cell, band)
+                        and not _is_in_merged_range(worksheet, cell.coordinate)
+                        and not _is_hidden_cell(worksheet, cell)
+                        and not _is_protected_target(worksheet)
+                        and row_semantics_safe
+                    ):
+                        formula, source = proposal
+                        patch = _make_patch(
+                            kind=PatchKind.SET_FORMULA,
+                            worksheet=worksheet,
+                            cell=cell,
+                            before=cell.value,
+                            after=formula,
+                            confidence=ratio,
+                            source_cell=source,
+                            description=(
+                                "Replace the one-off formula with the exact translated peer consensus."
+                            ),
+                        )
+                        patches.append(patch)
+                        result.patches.append(patch)
+                    result.findings.append(
+                        _make_finding(
+                            context=context,
+                            rule_id=self.rule_id,
+                            title=self.title,
+                            explanation=(
+                                "A formula has a different relative-reference signature from a "
+                                "strong band consensus."
+                            ),
+                            severity=Severity.WARNING,
+                            confidence=ratio,
+                            sheet=worksheet.title,
+                            location=cell.coordinate,
+                            evidence=Evidence(
+                                summary=(
+                                    f"{consensus_count} of {len(signatures)} formulas share one signature"
+                                ),
+                                observed=cell.value,
+                                expected=consensus,
+                                peers=peers[:12],
+                            ),
+                            expected=(
+                                "Copied formulas in this band have the same structural signature."
+                            ),
+                            suggested_action=(
+                                "Multiple isolated anomalies were found, so no automatic patch is "
+                                "offered; compare each cell with the listed peers."
+                                if len(outliers) > 1
+                                else "Aggregate formulas are never replaced automatically; review the "
+                                "subtotal or total manually."
+                                if aggregate_formula
+                                else "The row context does not match stable detail-row semantics, so "
+                                "automatic replacement is withheld."
+                                if not row_semantics_safe
+                                else "Compare the cell with the listed peers and review any proposed formula."
+                            ),
+                            patches=patches,
+                        )
+                    )
         return result
 
 
@@ -335,17 +858,37 @@ class BlankInFormulaBandRule(WorkbookRule):
                 if proposal is None:
                     continue
                 formula, source = proposal
-                patch = _make_patch(
-                    kind=PatchKind.CREATE_FORMULA,
-                    worksheet=worksheet,
-                    cell=cell,
-                    before=None,
-                    after=formula,
-                    confidence=0.99,
-                    source_cell=source,
-                    description="Create the missing cell with the exact translated formula agreed by peers.",
+                merged_cell = _is_in_merged_range(worksheet, cell.coordinate)
+                patches: list[PatchOperation] = []
+                hidden_cell = _is_hidden_cell(worksheet, cell)
+                protected_target = _is_protected_target(worksheet)
+                row_semantics_safe = (
+                    not _row_has_summary_semantics(worksheet, cell.row)
+                    and _row_label_matches_peer_template(context, worksheet, cell)
+                    and _row_visual_style_matches_peer_consensus(
+                        context, worksheet, cell, include_target=True
+                    )
                 )
-                result.patches.append(patch)
+                if (
+                    not merged_cell
+                    and not hidden_cell
+                    and not protected_target
+                    and row_semantics_safe
+                ):
+                    patch = _make_patch(
+                        kind=PatchKind.CREATE_FORMULA,
+                        worksheet=worksheet,
+                        cell=cell,
+                        before=None,
+                        after=formula,
+                        confidence=0.99,
+                        source_cell=source,
+                        description=(
+                            "Create the missing cell with the exact translated formula agreed by peers."
+                        ),
+                    )
+                    patches.append(patch)
+                    result.patches.append(patch)
                 result.findings.append(
                     _make_finding(
                         context=context,
@@ -363,8 +906,22 @@ class BlankInFormulaBandRule(WorkbookRule):
                             peers=[peer.coordinate for peer in formula_cells[:12]],
                         ),
                         expected="The contiguous formula band has no unexplained blank.",
-                        suggested_action="Review and select the proposed translated formula.",
-                        patches=[patch],
+                        suggested_action=(
+                            "The blank is inside a merged range and cannot safely receive a formula; "
+                            "review the merge manually."
+                            if merged_cell
+                            else "The blank is in a hidden sheet, row, or column, so automatic formula creation "
+                            "is withheld."
+                            if hidden_cell
+                            else "The blank is locked on a protected sheet, so automatic formula creation "
+                            "is withheld."
+                            if protected_target
+                            else "The row context does not match stable detail-row semantics, so automatic "
+                            "formula creation is withheld."
+                            if not row_semantics_safe
+                            else "Review and select the proposed translated formula."
+                        ),
+                        patches=patches,
                     )
                 )
         return result
@@ -406,7 +963,25 @@ class HardcodedValueInFormulaBandRule(WorkbookRule):
                 formula, source = proposal
                 confidence = 0.99 if ratio >= 0.95 else 0.94
                 patches: list[PatchOperation] = []
-                if confidence >= 0.95:
+                merged_cell = _is_in_merged_range(worksheet, cell.coordinate)
+                hidden_cell = _is_hidden_cell(worksheet, cell)
+                protected_target = _is_protected_target(worksheet)
+                row_semantics_safe = (
+                    not _row_has_summary_semantics(worksheet, cell.row)
+                    and _row_label_matches_peer_template(
+                        context, worksheet, cell, include_target=True
+                    )
+                    and _row_visual_style_matches_peer_consensus(
+                        context, worksheet, cell, include_target=True
+                    )
+                )
+                if (
+                    confidence >= 0.95
+                    and not merged_cell
+                    and not hidden_cell
+                    and not protected_target
+                    and row_semantics_safe
+                ):
                     patch = _make_patch(
                         kind=PatchKind.SET_FORMULA,
                         worksheet=worksheet,
@@ -436,7 +1011,18 @@ class HardcodedValueInFormulaBandRule(WorkbookRule):
                             peers=[peer.coordinate for peer in formula_cells[:12]],
                         ),
                         expected="The formula band follows its consensus structure.",
-                        suggested_action="Confirm the literal is not an intentional override before selecting the patch.",
+                        suggested_action=(
+                            "The cell is inside a merged range, so automatic replacement is withheld."
+                            if merged_cell
+                            else "The cell is in a hidden sheet, row, or column, so automatic replacement is withheld."
+                            if hidden_cell
+                            else "The cell is locked on a protected sheet, so automatic replacement is withheld."
+                            if protected_target
+                            else "The row context does not match stable detail-row semantics, so automatic "
+                            "replacement is withheld."
+                            if not row_semantics_safe
+                            else "Confirm the literal is not an intentional override before selecting the patch."
+                        ),
                         patches=patches,
                     )
                 )
@@ -470,14 +1056,40 @@ class SuspiciousSumBoundaryRule(WorkbookRule):
                 if candidate_row != cell.row - 1 or start_row >= end_row:
                     continue
                 candidate = _cell(worksheet, candidate_row, cell.column)
-                if isinstance(candidate.value, bool) or not isinstance(
-                    candidate.value, (int, float)
-                ):
+                if isinstance(candidate.value, bool):
                     continue
                 if worksheet.row_dimensions[candidate_row].hidden:
                     continue
                 if any(candidate.coordinate in merged for merged in worksheet.merged_cells.ranges):
                     continue
+                literal_candidate = isinstance(candidate.value, (int, float))
+                candidate_formula = (
+                    candidate.value
+                    if candidate.data_type == "f" and isinstance(candidate.value, str)
+                    else None
+                )
+                if not literal_candidate and candidate_formula is None:
+                    continue
+                candidate_summary = _row_has_summary_semantics(worksheet, candidate_row)
+                if candidate_formula is not None:
+                    if (
+                        _in_unsupported_formula_range(
+                            context, worksheet.title, candidate.coordinate
+                        )
+                        or _is_aggregate_formula(candidate_formula)
+                        or not _same_data_region(context, worksheet, candidate, cell)
+                    ):
+                        continue
+                    try:
+                        features = analyze_formula(candidate_formula)
+                    except (ValueError, UnsupportedFormulaError):
+                        continue
+                    if (
+                        features.broken_references
+                        or features.external_references
+                        or features.unsupported_reason
+                    ):
+                        continue
                 raw_end = match.group("end")
                 replacement_end = (
                     "$" + str(candidate_row) if raw_end.startswith("$") else str(candidate_row)
@@ -487,25 +1099,24 @@ class SuspiciousSumBoundaryRule(WorkbookRule):
                     + replacement_end
                     + cell.value[match.end("end") :]
                 )
-                patch = _make_patch(
-                    kind=PatchKind.EXTEND_SUM,
-                    worksheet=worksheet,
-                    cell=cell,
-                    before=cell.value,
-                    after=formula,
-                    confidence=0.96,
-                    source_cell=candidate.coordinate,
-                    description="Extend the simple SUM through the directly adjacent numeric peer.",
+                confidence = 0.96 if literal_candidate else 0.9
+                patches: list[PatchOperation] = []
+                target_blocked = bool(
+                    _is_in_merged_range(worksheet, cell.coordinate)
+                    or _is_hidden_cell(worksheet, cell)
+                    or _is_protected_target(worksheet)
                 )
-                result.patches.append(patch)
                 result.findings.append(
                     _make_finding(
                         context=context,
                         rule_id=self.rule_id,
                         title=self.title,
-                        explanation="A simple total stops one row before a directly adjacent non-hidden numeric peer.",
+                        explanation=(
+                            "A simple total stops one row before a directly adjacent non-hidden "
+                            f"{'numeric' if literal_candidate else 'formula'} peer."
+                        ),
                         severity=Severity.WARNING,
-                        confidence=0.96,
+                        confidence=confidence,
                         sheet=worksheet.title,
                         location=cell.coordinate,
                         evidence=Evidence(
@@ -515,8 +1126,18 @@ class SuspiciousSumBoundaryRule(WorkbookRule):
                             peers=[candidate.coordinate],
                         ),
                         expected="A simple contiguous total includes its directly adjacent peer row.",
-                        suggested_action="Check for intentional exclusions or subtotals, then select the patch if appropriate.",
-                        patches=[patch],
+                        suggested_action=(
+                            "The adjacent row has subtotal or total semantics, so automatic SUM "
+                            "extension is withheld."
+                            if candidate_summary
+                            else "The SUM target is merged, hidden, or locked on a protected sheet, "
+                            "so automatic extension is withheld."
+                            if target_blocked
+                            else "Review the adjacent peer manually. WorkbookLens reports the candidate "
+                            "formula but does not automatically extend SUM boundaries because inclusion "
+                            "semantics cannot be proven from adjacency alone."
+                        ),
+                        patches=patches,
                     )
                 )
         return result
@@ -526,15 +1147,20 @@ def _numeric_text(value: Any) -> int | float | None:
     if not isinstance(value, str):
         return None
     stripped = value.strip()
-    if not stripped or re.match(r"^[+-]?0\d+", stripped):
+    if not stripped:
         return None
     digits = re.sub(r"[^0-9]", "", stripped)
     if len(digits) > 15 or re.search(r"[()\-/]", stripped):
         return None
-    if not re.fullmatch(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)", stripped):
+    grouped = re.fullmatch(r"[+-]?\d{1,3}(?:,\d{3})+(?:\.\d+)?", stripped)
+    plain = re.fullmatch(r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)", stripped)
+    if grouped is None and plain is None:
+        return None
+    normalized = stripped.replace(",", "")
+    if re.match(r"^[+-]?0\d+", normalized):
         return None
     try:
-        number = Decimal(stripped)
+        number = Decimal(normalized)
     except InvalidOperation:
         return None
     if not number.is_finite():
@@ -566,6 +1192,9 @@ class NumericTextRule(WorkbookRule):
                     )
                     if numeric_count < 3:
                         continue
+                    header_value = _cell(worksheet, region.min_row, column).value
+                    identifier_header = _looks_like_identifier_header(header_value)
+                    measure_header = _looks_like_measure_header(header_value)
                     for cell in cells:
                         converted = _numeric_text(cell.value)
                         if converted is None or (worksheet.title, cell.coordinate) in seen:
@@ -575,8 +1204,34 @@ class NumericTextRule(WorkbookRule):
                             continue
                         seen.add((worksheet.title, cell.coordinate))
                         confidence = 0.97 if ratio >= 0.85 else 0.9
+                        text_formatted = cell.number_format == "@" or cell.quotePrefix
+                        grouped_numeric = isinstance(cell.value, str) and "," in cell.value
+                        row_semantics_safe = (
+                            not _row_has_summary_semantics(worksheet, cell.row)
+                            and _row_label_matches_peer_template(
+                                context,
+                                worksheet,
+                                cell,
+                                region,
+                                ignore_numeric_text=True,
+                                require_stable=False,
+                            )
+                            and _row_visual_style_matches_peer_consensus(
+                                context, worksheet, cell, region, include_target=True
+                            )
+                        )
                         patches: list[PatchOperation] = []
-                        if confidence >= 0.95:
+                        if (
+                            confidence >= 0.95
+                            and not identifier_header
+                            and measure_header
+                            and not text_formatted
+                            and not grouped_numeric
+                            and not _is_in_merged_range(worksheet, cell.coordinate)
+                            and not _is_hidden_cell(worksheet, cell)
+                            and not _is_protected_target(worksheet)
+                            and row_semantics_safe
+                        ):
                             patch = _make_patch(
                                 kind=PatchKind.SET_NUMERIC,
                                 worksheet=worksheet,
@@ -609,7 +1264,21 @@ class NumericTextRule(WorkbookRule):
                                     ][:12],
                                 ),
                                 expected="Numeric measures use numeric cell storage, while identifiers remain text.",
-                                suggested_action="Confirm the value is a measure rather than an identifier.",
+                                suggested_action=(
+                                    "Identifier semantics or explicit text formatting prevent automatic "
+                                    "numeric conversion; confirm storage intentionally."
+                                    if identifier_header or text_formatted
+                                    else "The header does not explicitly identify a numeric measure, so "
+                                    "automatic conversion is withheld; confirm the column semantics."
+                                    if not measure_header
+                                    else "Grouped numeric text is reported for review but is not converted "
+                                    "automatically in this release."
+                                    if grouped_numeric
+                                    else "The row context does not match stable detail-row semantics, so "
+                                    "automatic numeric conversion is withheld."
+                                    if not row_semantics_safe
+                                    else "Confirm the value is a measure rather than an identifier."
+                                ),
                                 patches=patches,
                             )
                         )
@@ -633,80 +1302,115 @@ class StyleOutlierRule(WorkbookRule):
                     ]
                     if len(cells) < 5:
                         continue
-                    counts = Counter(cell.style_id for cell in cells)
-                    style_id, count = counts.most_common(1)[0]
+                    style_by_cell = {cell.coordinate: _visual_style_key(cell) for cell in cells}
+                    counts = Counter(style_by_cell.values())
+                    consensus_style, count = counts.most_common(1)[0]
                     ratio = count / len(cells)
-                    outliers = [cell for cell in cells if cell.style_id != style_id]
-                    if ratio < 0.8 or len(outliers) != 1:
+                    outliers = [
+                        cell for cell in cells if style_by_cell[cell.coordinate] != consensus_style
+                    ]
+                    outlier_rows = sorted(cell.row for cell in outliers)
+                    if (
+                        ratio < 0.8
+                        or not outliers
+                        or any(right - left <= 1 for left, right in pairwise(outlier_rows))
+                    ):
                         continue
-                    cell = outliers[0]
-                    if (worksheet.title, cell.coordinate) in seen:
-                        continue
-                    seen.add((worksheet.title, cell.coordinate))
                     sources = [
                         peer
                         for peer in cells
-                        if peer.style_id == style_id
+                        if style_by_cell[peer.coordinate] == consensus_style
                         and not _in_unsupported_formula_range(
                             context, worksheet.title, peer.coordinate
                         )
                     ]
-                    source = (
-                        min(
-                            sources,
-                            key=lambda peer: (
-                                abs(peer.row - cell.row),
-                                peer.coordinate,
-                            ),
+                    for cell in outliers:
+                        if (worksheet.title, cell.coordinate) in seen:
+                            continue
+                        seen.add((worksheet.title, cell.coordinate))
+                        source = (
+                            min(
+                                sources,
+                                key=lambda peer: (
+                                    abs(peer.row - cell.row),
+                                    peer.coordinate,
+                                ),
+                            )
+                            if sources
+                            else None
                         )
-                        if sources
-                        else None
-                    )
-                    confidence = ratio
-                    patches: list[PatchOperation] = []
-                    if (
-                        confidence >= 0.95
-                        and source is not None
-                        and not _in_unsupported_formula_range(
-                            context, worksheet.title, cell.coordinate
+                        confidence = ratio
+                        patches: list[PatchOperation] = []
+                        row_semantics_safe = (
+                            not _row_has_summary_semantics(worksheet, cell.row)
+                            and _row_label_matches_peer_template(
+                                context, worksheet, cell, region, include_target=True
+                            )
+                            and _row_visual_style_matches_peer_consensus(
+                                context, worksheet, cell, region
+                            )
                         )
-                    ):
-                        patch = _make_patch(
-                            kind=PatchKind.COPY_STYLE,
-                            worksheet=worksheet,
-                            cell=cell,
-                            before=cell.style_id,
-                            after=style_id,
-                            confidence=confidence,
-                            source_cell=source.coordinate,
-                            description="Copy the existing consensus style ID from the nearest peer.",
+                        if (
+                            confidence >= 0.95
+                            and len(outliers) == 1
+                            and source is not None
+                            and _style_copy_preserves_semantics(cell, source)
+                            and not worksheet.protection.sheet
+                            and not _is_in_merged_range(worksheet, cell.coordinate)
+                            and not _is_hidden_cell(worksheet, cell)
+                            and row_semantics_safe
+                            and not _in_unsupported_formula_range(
+                                context, worksheet.title, cell.coordinate
+                            )
+                        ):
+                            patch = _make_patch(
+                                kind=PatchKind.COPY_STYLE,
+                                worksheet=worksheet,
+                                cell=cell,
+                                before=cell.style_id,
+                                after=source.style_id,
+                                confidence=confidence,
+                                source_cell=source.coordinate,
+                                description="Copy the existing consensus style ID from the nearest peer.",
+                            )
+                            patches.append(patch)
+                            result.patches.append(patch)
+                        result.findings.append(
+                            _make_finding(
+                                context=context,
+                                rule_id=self.rule_id,
+                                title=self.title,
+                                explanation="A populated cell has a different visual style from its column peers.",
+                                severity=Severity.INFO,
+                                confidence=confidence,
+                                sheet=worksheet.title,
+                                location=cell.coordinate,
+                                evidence=Evidence(
+                                    summary=(
+                                        f"One visual style appears in {count} of {len(cells)} peer cells"
+                                    ),
+                                    observed=cell.style_id,
+                                    expected=source.style_id if source is not None else None,
+                                    peers=[
+                                        peer.coordinate
+                                        for peer in cells
+                                        if style_by_cell[peer.coordinate] == consensus_style
+                                    ][:12],
+                                    details={"number_format": cell.number_format},
+                                ),
+                                expected="A homogeneous measure column uses its consensus style.",
+                                suggested_action=(
+                                    "Multiple isolated style anomalies were found, so no automatic patch "
+                                    "is offered."
+                                    if len(outliers) > 1
+                                    else "The row context does not match stable detail-row semantics, so no "
+                                    "automatic style patch is offered."
+                                    if not row_semantics_safe
+                                    else "Check whether the visual distinction is intentional."
+                                ),
+                                patches=patches,
+                            )
                         )
-                        patches.append(patch)
-                        result.patches.append(patch)
-                    result.findings.append(
-                        _make_finding(
-                            context=context,
-                            rule_id=self.rule_id,
-                            title=self.title,
-                            explanation="One populated cell uses a different existing style ID from its column peers.",
-                            severity=Severity.INFO,
-                            confidence=confidence,
-                            sheet=worksheet.title,
-                            location=cell.coordinate,
-                            evidence=Evidence(
-                                summary=f"Style {style_id} appears in {count} of {len(cells)} peer cells",
-                                observed=cell.style_id,
-                                expected=style_id,
-                                peers=[
-                                    peer.coordinate for peer in cells if peer.style_id == style_id
-                                ][:12],
-                                details={"number_format": cell.number_format},
-                            ),
-                            expected="A homogeneous measure column uses its consensus style.",
-                            suggested_action="Check whether the visual distinction is intentional.",
-                            patches=patches,
-                        )
-                    )
         return result
 
 
@@ -760,13 +1464,9 @@ class HiddenNonemptyDataRule(WorkbookRule):
                         suggested_action="Review the row manually; no automatic unhide is offered.",
                     )
                 )
-            for _column, column_dimension in sorted(worksheet.column_dimensions.items()):
-                min_column = column_dimension.min
-                max_column = column_dimension.max
-                if min_column is None or max_column is None:
-                    continue
+            for min_column, max_column in hidden_column_spans(worksheet):
                 cells = [cell for cell in nonempty if min_column <= cell.column <= max_column]
-                if not column_dimension.hidden or not cells:
+                if not cells:
                     continue
                 location = f"{get_column_letter(min_column)}:{get_column_letter(max_column)}"
                 result.findings.append(

--- a/src/workbooklens/snapshot.py
+++ b/src/workbooklens/snapshot.py
@@ -15,6 +15,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from workbooklens.models import CellSnapshot, SheetSnapshot, WorkbookSnapshot
 from workbooklens.ooxml.safety import PackageLimits, inspect_package
 from workbooklens.utils import sha256_bytes, sha256_file, stable_json_bytes
+from workbooklens.worksheet_state import hidden_column_labels, is_column_hidden
 
 
 def _formula_payload(cell: Cell) -> str | None:
@@ -45,6 +46,7 @@ def cell_semantic_payload(cell: Cell) -> dict[str, Any]:
         "data_type": cell.data_type,
         "style_id": cell.style_id,
         "number_format": cell.number_format,
+        "quote_prefix": bool(cell.quotePrefix),
     }
 
 
@@ -109,12 +111,13 @@ def style_fingerprint(cell: Cell) -> str:
 
 def _snapshot_cell(cell: Cell, worksheet: Worksheet) -> CellSnapshot:
     payload = cell_semantic_payload(cell)
-    column_letter = cell.column_letter
+    snapshot_payload = dict(payload)
+    snapshot_payload.pop("quote_prefix", None)
     return CellSnapshot(
-        **payload,
+        **snapshot_payload,
         style_fingerprint=style_fingerprint(cell),
         row_hidden=bool(worksheet.row_dimensions[cell.row].hidden),
-        column_hidden=bool(worksheet.column_dimensions[column_letter].hidden),
+        column_hidden=is_column_hidden(worksheet, cell.column),
     )
 
 
@@ -170,11 +173,7 @@ def snapshot_from_workbook(workbook: Workbook, path: Path, source_sha256: str) -
                     for index, dimension in worksheet.row_dimensions.items()
                     if dimension.hidden
                 ),
-                hidden_columns=sorted(
-                    key
-                    for key, dimension in worksheet.column_dimensions.items()
-                    if dimension.hidden
-                ),
+                hidden_columns=hidden_column_labels(worksheet),
                 data_validations=sorted(validations),
             )
         )

--- a/src/workbooklens/worksheet_state.py
+++ b/src/workbooklens/worksheet_state.py
@@ -1,0 +1,67 @@
+"""Range-aware worksheet visibility helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from openpyxl.utils.cell import column_index_from_string, get_column_letter
+from openpyxl.worksheet.dimensions import ColumnDimension
+from openpyxl.worksheet.worksheet import Worksheet
+
+from workbooklens.exceptions import UnsafeWorkbookError
+
+MAX_EXCEL_COLUMN = 16_384
+
+
+def _validate_span(min_column: int, max_column: int) -> tuple[int, int]:
+    if 1 <= min_column <= max_column <= MAX_EXCEL_COLUMN:
+        return min_column, max_column
+    raise UnsafeWorkbookError(
+        f"Hidden column span {min_column}:{max_column} is outside Excel's valid A:XFD range"
+    )
+
+
+def _column_span(dimension: ColumnDimension) -> tuple[int, int] | None:
+    min_column = dimension.min
+    max_column = dimension.max
+    if isinstance(min_column, int) and isinstance(max_column, int):
+        return _validate_span(min_column, max_column)
+    index = dimension.index
+    if not isinstance(index, str):
+        return None
+    try:
+        column = column_index_from_string(index)
+    except ValueError:
+        raise UnsafeWorkbookError(f"Invalid hidden column dimension index {index!r}") from None
+    return _validate_span(column, column)
+
+
+def hidden_column_spans(worksheet: Worksheet) -> Iterator[tuple[int, int]]:
+    """Yield every hidden column span, including grouped dimensions."""
+
+    for dimension in worksheet.column_dimensions.values():
+        if not dimension.hidden:
+            continue
+        span = _column_span(dimension)
+        if span is not None:
+            yield span
+
+
+def is_column_hidden(worksheet: Worksheet, column: int) -> bool:
+    """Return whether a column falls inside any hidden dimension span."""
+
+    return any(
+        min_column <= column <= max_column
+        for min_column, max_column in hidden_column_spans(worksheet)
+    )
+
+
+def hidden_column_labels(worksheet: Worksheet) -> list[str]:
+    """Expand hidden dimension spans to deterministic column labels."""
+
+    columns = {
+        get_column_letter(column)
+        for min_column, max_column in hidden_column_spans(worksheet)
+        for column in range(min_column, max_column + 1)
+    }
+    return sorted(columns, key=column_index_from_string)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -22,7 +22,7 @@ def test_help_version_and_required_commands() -> None:
         assert command in help_result.stdout
     version_result = runner.invoke(app, ["--version"])
     assert version_result.exit_code == 0
-    assert "WorkbookLens 2.0.0" in version_result.stdout
+    assert "WorkbookLens 2.1.0" in version_result.stdout
 
 
 def test_scan_outputs_and_fail_on_exit_code(tmp_path: Path) -> None:

--- a/tests/integration/test_repair_workflow.py
+++ b/tests/integration/test_repair_workflow.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from lxml import etree
 from openpyxl import Workbook, load_workbook
+from openpyxl.chart import LineChart, Reference
 
 from workbooklens.demo import run_demo
 from workbooklens.demo.workflow import DemoOutput, generate_demo_workbook
@@ -28,22 +29,22 @@ def _plan(path: Path) -> PatchPlan:
     return build_patch_plan(scan_workbook(path, config=config))
 
 
-def test_demo_applies_all_five_patch_types_and_reopens(completed_demo: DemoOutput) -> None:
+def test_demo_applies_four_safe_patch_types_and_reopens(completed_demo: DemoOutput) -> None:
     plan = PatchPlan.model_validate_json(completed_demo.repair_plan.read_text(encoding="utf-8"))
     report_path = completed_demo.directory / "apply-report.json"
     result = PatchResult.model_validate_json(report_path.read_text(encoding="utf-8"))
-    assert len(plan.patches) == 5
+    assert len(plan.patches) == 4
     assert plan.findings
     assert {finding.id for finding in plan.findings} == set(plan.finding_ids)
     assert all(finding.evidence.summary for finding in plan.findings)
-    assert len(result.applied_patch_ids) == 5
+    assert len(result.applied_patch_ids) == 4
     assert result.source_sha256 == sha256_file(completed_demo.before_workbook)
     assert result.output_sha256 == sha256_file(completed_demo.after_workbook)
     workbook = load_workbook(completed_demo.after_workbook, read_only=True, data_only=False)
     assert workbook["Sales"]["D8"].value == "=B8*C8"
     assert workbook["Sales"]["E12"].value == "=D12*0.08"
     assert workbook["Sales"]["B10"].value == 12
-    assert workbook["Summary"]["B10"].value == "=SUM(B2:B9)"
+    assert workbook["Summary"]["B10"].value == "=SUM(B2:B8)"
     workbook.close()
 
 
@@ -57,7 +58,6 @@ def test_only_manifested_parts_change_and_chart_is_byte_identical(
     assert changed == {
         "xl/workbook.xml",
         "xl/worksheets/sheet1.xml",
-        "xl/worksheets/sheet2.xml",
     }
     with (
         zipfile.ZipFile(completed_demo.before_workbook) as before_archive,
@@ -69,6 +69,50 @@ def test_only_manifested_parts_change_and_chart_is_byte_identical(
         for name in before_archive.namelist():
             if name not in changed:
                 assert before_archive.read(name) == after_archive.read(name), name
+
+
+def test_chartsheet_is_skipped_and_preserved_during_scan_and_apply(tmp_path: Path) -> None:
+    source = tmp_path / "chartsheet-source.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Data"
+    worksheet.append(["Month", "Value", "Double"])
+    for row in range(2, 22):
+        worksheet.append([f"M{row - 1}", row, None])
+        worksheet[f"C{row}"] = f"=B{row}*2"
+    worksheet["C12"] = None
+    chart = LineChart()
+    chart.add_data(Reference(worksheet, min_col=2, min_row=1, max_row=21), titles_from_data=True)
+    chart.set_categories(Reference(worksheet, min_col=1, min_row=2, max_row=21))
+    chartsheet = workbook.create_chartsheet("Trend")
+    chartsheet.add_chart(chart)
+    workbook.save(source)
+    workbook.close()
+
+    scan = scan_workbook(source)
+    assert any(patch.cell == "C12" for patch in scan.patches)
+    plan = build_patch_plan(scan)
+    output = tmp_path / "chartsheet-fixed.xlsx"
+    apply_patch_plan(source, plan, output, safe_only=True)
+
+    with zipfile.ZipFile(source) as before, zipfile.ZipFile(output) as after:
+        preserved = [
+            name
+            for name in before.namelist()
+            if name.startswith(("xl/chartsheets/", "xl/charts/", "xl/drawings/"))
+        ]
+        assert preserved
+        assert before.namelist() == after.namelist()
+        for name in preserved:
+            assert before.read(name) == after.read(name), name
+
+    reopened = load_workbook(output, read_only=False, data_only=False)
+    try:
+        assert reopened.sheetnames == ["Data", "Trend"]
+        assert reopened["Data"]["C12"].value == "=B12*2"
+    finally:
+        reopened.close()
 
 
 def test_formula_repairs_remove_cache_and_request_full_recalculation(
@@ -154,6 +198,18 @@ def test_selection_and_output_safety_fail_closed(tmp_path: Path) -> None:
     assert existing.read_bytes() == b"do not overwrite"
     with pytest.raises(UsageError, match="source workbook is never overwritten"):
         patch_ooxml_package(source, plan, source, safe_only=True, canonical_plan=plan)
+
+    conflicting = plan.model_copy(deep=True)
+    duplicate = conflicting.patches[0].model_copy(update={"id": "patch-conflicting-copy"})
+    conflicting.patches.append(duplicate)
+    with pytest.raises(UsageError, match="Conflicting patches target the same cell"):
+        patch_ooxml_package(
+            source,
+            conflicting,
+            tmp_path / "conflicting-target.xlsx",
+            safe_only=True,
+            canonical_plan=conflicting,
+        )
 
 
 def test_patch_plan_input_is_size_bounded(tmp_path: Path) -> None:

--- a/tests/integration/test_web.py
+++ b/tests/integration/test_web.py
@@ -34,7 +34,7 @@ def test_local_web_scan_apply_and_download_workflow(tmp_path: Path) -> None:
         assert session_match
         session_id = session_match.group(1)
         patch_ids = re.findall(r'name="patch_id" value="([^"]+)"', response.text)
-        assert len(patch_ids) == 5
+        assert len(patch_ids) == 4
         report = client.get(f"/sessions/{session_id}/report")
         assert report.status_code == 200
         assert report.headers["content-disposition"].startswith("inline")

--- a/tests/security/test_package_safety.py
+++ b/tests/security/test_package_safety.py
@@ -14,6 +14,7 @@ from workbooklens.ooxml.safety import (
     inspect_package,
     parse_xml_part,
 )
+from workbooklens.worksheet_state import hidden_column_labels
 
 CONTENT_TYPES = b'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>'
 WORKBOOK = b'<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>'
@@ -161,3 +162,17 @@ def test_file_size_limit_precedes_zip_parsing(tmp_path: Path) -> None:
     path.write_bytes(b"x" * 11)
     with pytest.raises(UnsafeWorkbookError, match="configured limit"):
         inspect_package(path, PackageLimits(max_file_bytes=10))
+
+
+def test_hidden_column_span_cannot_expand_beyond_excel_limit() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    dimension = worksheet.column_dimensions["A"]
+    dimension.hidden = True
+    dimension.min = 1
+    dimension.max = 10**9
+
+    with pytest.raises(UnsafeWorkbookError, match="A:XFD"):
+        hidden_column_labels(worksheet)
+    workbook.close()

--- a/tests/security/test_v2_repair_integrity.py
+++ b/tests/security/test_v2_repair_integrity.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import pytest
 from lxml import etree
+from openpyxl import load_workbook
+from openpyxl.styles import Protection
 
 import workbooklens.repair.ooxml_patch as ooxml_patch
 from workbooklens.demo.workflow import generate_demo_workbook
@@ -21,6 +23,8 @@ from workbooklens.models import PatchKind, PatchOperation, PatchPlan
 from workbooklens.ooxml.safety import PackageLimits, inspect_package
 from workbooklens.repair import apply_patch_plan, build_patch_plan
 from workbooklens.scanner import scan_workbook
+from workbooklens.snapshot import cell_fingerprint
+from workbooklens.utils import sha256_file
 
 CONTENT_TYPES_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
 RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
@@ -230,3 +234,75 @@ def test_precondition_analysis_receives_original_package_limits(
     assert received == [limits]
     assert received[0] is limits
     assert output.exists()
+
+
+@pytest.mark.parametrize("hidden_target", ["sheet", "row", "grouped_column"])
+def test_low_level_repair_rejects_newly_hidden_targets(tmp_path: Path, hidden_target: str) -> None:
+    source = tmp_path / f"hidden-{hidden_target}.xlsx"
+    generate_demo_workbook(source)
+    plan = _plan(source)
+    patch = _formula_patch(plan)
+
+    workbook = load_workbook(source)
+    worksheet = workbook[patch.sheet]
+    if hidden_target == "sheet":
+        worksheet.sheet_state = "hidden"
+    elif hidden_target == "row":
+        worksheet.row_dimensions[worksheet[patch.cell].row].hidden = True
+    else:
+        worksheet.column_dimensions.group("B", "D", hidden=True)
+    workbook.save(source)
+    workbook.close()
+    plan.source_sha256 = sha256_file(source)
+
+    output = tmp_path / f"hidden-{hidden_target}-fixed.xlsx"
+    with pytest.raises(PatchValidationError, match=r"hidden|non-visible"):
+        ooxml_patch.patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    ("semantic", "expected_message"),
+    [
+        ("protection", "protection semantics"),
+        ("number_format", "number-format semantics"),
+        ("quote_prefix", "quote-prefix semantics"),
+        ("pivot_button", "pivot-button semantics"),
+    ],
+)
+def test_low_level_style_copy_rejects_semantic_mismatch(
+    tmp_path: Path, semantic: str, expected_message: str
+) -> None:
+    source = tmp_path / f"style-{semantic}.xlsx"
+    generate_demo_workbook(source)
+    plan = _plan(source)
+    patch = next(item for item in plan.patches if item.kind == PatchKind.COPY_STYLE)
+
+    workbook = load_workbook(source)
+    worksheet = workbook[patch.sheet]
+    target = worksheet[patch.cell]
+    if semantic == "protection":
+        target.protection = Protection(locked=False)
+    elif semantic == "number_format":
+        target.number_format = "0.00%"
+    elif semantic == "quote_prefix":
+        target.quotePrefix = not target.quotePrefix
+    else:
+        target.pivotButton = not target.pivotButton
+    workbook.save(source)
+    workbook.close()
+
+    workbook = load_workbook(source)
+    target = workbook[patch.sheet][patch.cell]
+    plan.source_sha256 = sha256_file(source)
+    patch.precondition.cell_fingerprint = cell_fingerprint(target)
+    workbook.close()
+
+    with pytest.raises(PatchValidationError, match=expected_message):
+        ooxml_patch._verify_preconditions(source, plan, [patch], None)

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from openpyxl import Workbook
+from openpyxl.styles import Font, PatternFill, Protection
 
 from workbooklens.demo.workflow import generate_demo_workbook
 from workbooklens.models import PatchKind
@@ -19,7 +20,7 @@ def demo_scan(tmp_path_factory: pytest.TempPathFactory) -> ScanResult:
     return scan_workbook(path, config=config)
 
 
-def test_demo_exercises_fourteen_rules_and_all_patch_kinds(demo_scan: ScanResult) -> None:
+def test_demo_exercises_fourteen_rules_and_generated_patch_kinds(demo_scan: ScanResult) -> None:
     rule_ids = {finding.rule_id for finding in demo_scan.findings}
     assert rule_ids == {
         "WL001_BROKEN_REFERENCE",
@@ -37,7 +38,7 @@ def test_demo_exercises_fourteen_rules_and_all_patch_kinds(demo_scan: ScanResult
         "WL014_MERGED_CELL_IN_DATA_REGION",
         "WL015_INCONSISTENT_DATA_VALIDATION",
     }
-    assert {patch.kind for patch in demo_scan.patches} == set(PatchKind)
+    assert {patch.kind for patch in demo_scan.patches} == set(PatchKind) - {PatchKind.EXTEND_SUM}
     assert all(patch.safe and float(patch.confidence) >= 0.95 for patch in demo_scan.patches)
 
 
@@ -66,6 +67,176 @@ def test_formula_pattern_outlier_rule_and_safe_proposal(tmp_path: Path) -> None:
     assert len(patches) == 1
     assert patches[0].kind == PatchKind.SET_FORMULA
     assert patches[0].after == "=K1*2"
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "=SUM(B2:T2)",
+        "=SUBTOTAL(9,B2:T2)",
+        "=AGGREGATE(9,5,B2:T2)",
+        "=SUM(B2:T2)+0",
+        "=ROUND(SUM(B2:T2),2)",
+        "=SUM(B2:T2,N(0))",
+        "=SUM(B2:T2)+IFERROR(0,0)",
+        "=AVERAGE(B2:T2)",
+        "=MIN(B2:T2)",
+        "=MAX(B2:T2)",
+        "=COUNT(B2:T2)",
+        "=COUNTA(B2:T2)",
+        "=MEDIAN(B2:T2)",
+    ],
+)
+def test_boundary_aggregate_is_not_treated_as_formula_outlier(tmp_path: Path, formula: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for column in range(2, 21):
+        worksheet.cell(1, column, column)
+        coordinate = worksheet.cell(2, column).coordinate
+        source = worksheet.cell(1, column).coordinate
+        worksheet[coordinate] = f"={source}*2"
+    worksheet["U2"] = formula
+    path = tmp_path / "boundary-total.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert not any(
+        finding.rule_id == "WL002_FORMULA_PATTERN_OUTLIER" and finding.location == "U2"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "U2" for patch in scan.patches)
+
+
+def test_multiple_isolated_formula_outliers_are_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for column in range(2, 22):
+        worksheet.cell(1, column, column)
+        coordinate = worksheet.cell(2, column).coordinate
+        source = worksheet.cell(1, column).coordinate
+        worksheet[coordinate] = f"={source}*2"
+    worksheet["K2"] = "=K1*3"
+    worksheet["Q2"] = "=Q1+7"
+    path = tmp_path / "multiple-outliers.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    findings = {
+        finding.location
+        for finding in scan.findings
+        if finding.rule_id == "WL002_FORMULA_PATTERN_OUTLIER"
+    }
+    assert findings == {"K2", "Q2"}
+    assert not any(patch.cell in findings for patch in scan.patches)
+
+
+def test_merged_formula_outlier_is_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 22):
+        worksheet[f"B{row}"] = f"=A{row}*2"
+    worksheet["B10"] = "=A10*3"
+    worksheet.merge_cells("B10:C10")
+    path = tmp_path / "merged-formula-outlier.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL002_FORMULA_PATTERN_OUTLIER" and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "Subtotal",
+        "Sub-total",
+        "Grand-total",
+        "Average",
+        "Mean",
+        "Minimum",
+        "Maximum",
+        "Summary",
+        "小计",
+        "小计金额",
+        "合计金额",
+        "汇总金额",
+        "平均金额",
+        "最大金额",
+        "最小金额",
+        "总金额",
+        "累计金额",
+        "净额",
+        "期末余额",
+    ],
+)
+def test_summary_row_formula_outlier_is_findings_only(tmp_path: Path, label: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A2"] = label
+    for column in range(2, 22):
+        coordinate = worksheet.cell(2, column).coordinate
+        source = worksheet.cell(1, column).coordinate
+        worksheet[coordinate] = f"={source}*2"
+    worksheet["K2"] = "=K1*3"
+    path = tmp_path / f"summary-formula-outlier-{len(label)}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL002_FORMULA_PATTERN_OUTLIER" and finding.location == "K2"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "K2" for patch in scan.patches)
+
+
+def test_hidden_formula_outlier_is_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 22):
+        worksheet[f"B{row}"] = f"=A{row}*2"
+    worksheet["B10"] = "=A10*3"
+    worksheet.row_dimensions[10].hidden = True
+    path = tmp_path / "hidden-formula-outlier.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL002_FORMULA_PATTERN_OUTLIER" and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+def test_formula_band_boundary_never_gets_automatic_replacement(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Band"
+    for column in range(2, 21):
+        worksheet.cell(1, column, column)
+        coordinate = worksheet.cell(2, column).coordinate
+        source = worksheet.cell(1, column).coordinate
+        worksheet[coordinate] = f"={source}*2"
+    worksheet["U2"] = "=AVERAGE(Band!B2:T2)"
+    path = tmp_path / "explicit-sheet-boundary-summary.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert not any(patch.cell == "U2" for patch in scan.patches)
 
 
 def test_finding_identity_is_stable_when_evidence_content_changes(tmp_path: Path) -> None:
@@ -156,6 +327,614 @@ def test_numeric_text_excludes_leading_zero_identifiers(demo_scan: ScanResult) -
     assert locations == {"B10"}
 
 
+@pytest.mark.parametrize(
+    "header",
+    [
+        "Customer ID",
+        "SKU",
+        "Account Number",
+        "Postal Code",
+        "Phone Number",
+        "Mobile Number",
+        "SSN",
+        "ISBN",
+        "手机号",
+        "证件号码",
+        "银行卡号",
+        "客户编号",
+    ],
+)
+def test_identifier_headers_suppress_numeric_text_patch(tmp_path: Path, header: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append([header, "Amount"])
+    for row in range(2, 22):
+        worksheet.append([10000 + row, row * 10])
+    worksheet["A10"] = "12345"
+    path = tmp_path / f"identifier-{len(header)}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "A10"
+    )
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "A10" for patch in scan.patches)
+
+
+def test_account_balance_still_allows_numeric_measure_patch(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Account Balance", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1200"
+    path = tmp_path / "account-balance.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        patch.kind == PatchKind.SET_NUMERIC and patch.cell == "A10" for patch in scan.patches
+    )
+
+
+def test_measure_patch_survives_plain_numeric_text_in_identifier_column(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Account ID", "Customer", "Credit Limit"])
+    for row in range(2, 22):
+        worksheet.append([10000 + row, f"Customer {row}", row * 1000])
+    worksheet["A10"] = "12345"
+    worksheet["C10"] = "12000"
+    path = tmp_path / "identifier-and-measure-numeric-text.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    patches = {(patch.kind, patch.cell) for patch in scan.patches}
+    assert (PatchKind.SET_NUMERIC, "A10") not in patches
+    assert (PatchKind.SET_NUMERIC, "C10") in patches
+
+
+def test_unknown_numeric_column_is_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Business Field", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1200"
+    path = tmp_path / "unknown-numeric-column.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "A10" for patch in scan.patches)
+
+
+def test_explicit_text_format_suppresses_numeric_text_patch(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Measure", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1200"
+    worksheet["A10"].number_format = "@"
+    path = tmp_path / "explicit-text.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "A10" for patch in scan.patches)
+
+
+def test_quote_prefix_suppresses_numeric_and_style_patches(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Measure", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1200"
+    worksheet["A10"].quotePrefix = True
+    path = tmp_path / "quote-prefix.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(
+        patch.cell == "A10" and patch.kind in {PatchKind.SET_NUMERIC, PatchKind.COPY_STYLE}
+        for patch in scan.patches
+    )
+
+
+def test_protected_worksheet_is_findings_only_for_numeric_text(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Amount", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1200"
+    worksheet.protection.sheet = True
+    path = tmp_path / "protected-numeric.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "A10" for patch in scan.patches)
+
+
+def test_grouped_numeric_text_is_reported_without_auto_patch(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Amount", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1,200"
+    path = tmp_path / "grouped-numeric.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "A10" for patch in scan.patches)
+
+
+def test_grouped_hidden_nonleading_column_is_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Context", "Amount", "Reviewer"])
+    for row in range(2, 22):
+        worksheet.append([f"R{row}", f"C{row}", row * 100, "Chen"])
+    worksheet["C10"] = "1200"
+    worksheet.column_dimensions.group("B", "D", hidden=True)
+    path = tmp_path / "grouped-hidden-nonleading-column.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "C10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "C10" for patch in scan.patches)
+    snapshot_sheet = scan.snapshot.sheets[0]
+    assert snapshot_sheet.hidden_columns == ["B", "C", "D"]
+    assert snapshot_sheet.cells["C10"].column_hidden
+
+
+@pytest.mark.parametrize("sheet_state", ["hidden", "veryHidden"])
+def test_nonvisible_worksheet_is_findings_only_for_numeric_text(
+    tmp_path: Path, sheet_state: str
+) -> None:
+    workbook = Workbook()
+    cover = workbook.active
+    assert cover is not None
+    cover.title = "Cover"
+    worksheet = workbook.create_sheet("Data")
+    worksheet.append(["Amount", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"R{row}"])
+    worksheet["A10"] = "1200"
+    worksheet.sheet_state = sheet_state
+    path = tmp_path / f"{sheet_state}-numeric.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL006_NUMERIC_TEXT"
+        and finding.sheet == "Data"
+        and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(patch.sheet == "Data" for patch in scan.patches)
+
+
+@pytest.mark.parametrize("sheet_state", ["hidden", "veryHidden"])
+def test_nonvisible_worksheet_is_findings_only_for_formula_and_style(
+    tmp_path: Path, sheet_state: str
+) -> None:
+    workbook = Workbook()
+    cover = workbook.active
+    assert cover is not None
+    cover.title = "Cover"
+    worksheet = workbook.create_sheet("Data")
+    worksheet.append(["Amount", "Calculated"])
+    for row in range(2, 22):
+        worksheet.append([row * 100, f"=A{row}*2"])
+    worksheet["B10"] = 999
+    worksheet["A11"].font = Font(bold=True)
+    worksheet.sheet_state = sheet_state
+    path = tmp_path / f"{sheet_state}-formula-style.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL004_HARDCODED_VALUE_IN_FORMULA_BAND"
+        and finding.sheet == "Data"
+        and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert any(
+        finding.rule_id == "WL007_STYLE_OUTLIER"
+        and finding.sheet == "Data"
+        and finding.location == "A11"
+        for finding in scan.findings
+    )
+    assert not any(patch.sheet == "Data" for patch in scan.patches)
+
+
+@pytest.mark.parametrize("sheet_state", ["hidden", "veryHidden"])
+def test_nonvisible_worksheet_sum_boundary_is_findings_only(
+    tmp_path: Path, sheet_state: str
+) -> None:
+    workbook = Workbook()
+    cover = workbook.active
+    assert cover is not None
+    cover.title = "Cover"
+    worksheet = workbook.create_sheet("Data")
+    for row in range(2, 10):
+        worksheet.cell(row, 1, f"R{row}")
+        worksheet.cell(row, 2, row * 100)
+    worksheet["A10"] = "Total"
+    worksheet["B10"] = "=SUM(B2:B8)"
+    worksheet.sheet_state = sheet_state
+    path = tmp_path / f"{sheet_state}-sum-boundary.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY" and finding.sheet == "Data"
+    )
+    assert not finding.safe_patch_available
+    assert not any(patch.sheet == "Data" for patch in scan.patches)
+
+
+def test_protection_only_difference_is_not_a_visual_style_outlier(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Input", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row, f"R{row}"])
+    worksheet["A10"].protection = Protection(locked=False)
+    worksheet.protection.sheet = True
+    path = tmp_path / "unlocked-style-outlier.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert not any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(
+        patch.kind == PatchKind.COPY_STYLE and patch.cell == "A10" for patch in scan.patches
+    )
+
+
+def test_style_outlier_with_different_number_format_has_no_patch(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Customer ID", "Context"])
+    for row in range(2, 22):
+        worksheet.append([10000 + row, f"R{row}"])
+    worksheet["A10"].number_format = "000000"
+    path = tmp_path / "identifier-number-format-outlier.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "A10"
+    )
+    assert not finding.safe_patch_available
+    assert not any(
+        patch.kind == PatchKind.COPY_STYLE and patch.cell == "A10" for patch in scan.patches
+    )
+
+
+def test_pivot_button_only_difference_is_not_a_visual_style_outlier(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Amount", "Context"])
+    for row in range(2, 22):
+        worksheet.append([row, f"R{row}"])
+    worksheet["A10"].pivotButton = True
+    path = tmp_path / "pivot-button-style.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert not any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "A10"
+        for finding in scan.findings
+    )
+    assert not any(
+        patch.kind == PatchKind.COPY_STYLE and patch.cell == "A10" for patch in scan.patches
+    )
+
+
+def test_multiple_style_outliers_are_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Amount", "Context"])
+    for row in range(2, 24):
+        worksheet.append([row, f"R{row}"])
+    worksheet["A8"].font = Font(bold=True)
+    worksheet["A18"].font = Font(italic=True)
+    path = tmp_path / "multiple-style-outliers.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    locations = {
+        finding.location for finding in scan.findings if finding.rule_id == "WL007_STYLE_OUTLIER"
+    }
+    assert locations == {"A8", "A18"}
+    assert not any(
+        patch.kind == PatchKind.COPY_STYLE and patch.cell in locations for patch in scan.patches
+    )
+
+
+@pytest.mark.parametrize("label", ["Grand Total", "Summary", "总金额", "累计金额", "期末余额"])
+def test_summary_row_style_outliers_are_never_auto_copied(tmp_path: Path, label: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Amount"])
+    for row in range(2, 22):
+        worksheet.append([f"R{row}", row * 10])
+    worksheet.append([label, "=SUM(B2:B21)"])
+    worksheet["A22"].font = Font(bold=True)
+    worksheet["B22"].font = Font(bold=True)
+    path = tmp_path / "summary-row-style.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert not any(
+        patch.kind == PatchKind.COPY_STYLE and patch.cell in {"A22", "B22"}
+        for patch in scan.patches
+    )
+
+
+@pytest.mark.parametrize("label", ["Total", "Summary", "总金额", "累计金额", "期末余额"])
+def test_summary_row_numeric_text_is_findings_only(tmp_path: Path, label: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Amount"])
+    for row in range(2, 22):
+        worksheet.append([f"R{row}", row * 100])
+    worksheet["A10"] = label
+    worksheet["B10"] = "1200"
+    path = tmp_path / f"summary-numeric-{len(label)}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == "WL006_NUMERIC_TEXT" and finding.location == "B10"
+    )
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+def test_secondary_row_semantic_override_blocks_all_candidate_patches(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Row type", "Amount", "Calculated"])
+    for row in range(2, 22):
+        worksheet.append([f"Item {row}", "Regular", row * 100, f"=C{row}*2"])
+    worksheet["B10"] = "Manual override"
+    worksheet["C10"] = "1200"
+    worksheet["C10"].font = Font(bold=True)
+    worksheet["D10"] = 999
+    path = tmp_path / "secondary-row-semantic-override.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    findings = {(finding.rule_id, finding.location) for finding in scan.findings}
+    assert ("WL004_HARDCODED_VALUE_IN_FORMULA_BAND", "D10") in findings
+    assert ("WL006_NUMERIC_TEXT", "C10") in findings
+    assert ("WL007_STYLE_OUTLIER", "C10") in findings
+    assert not any(patch.cell in {"C10", "D10"} for patch in scan.patches)
+
+
+@pytest.mark.parametrize(
+    ("fault", "rule_id"),
+    [
+        ("formula", "WL002_FORMULA_PATTERN_OUTLIER"),
+        ("blank", "WL003_BLANK_IN_FORMULA_BAND"),
+    ],
+)
+def test_secondary_row_semantic_override_blocks_formula_candidate_patches(
+    tmp_path: Path, fault: str, rule_id: str
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Row type", "Input", "Calculated"])
+    for row in range(2, 22):
+        worksheet.append([f"Item {row}", "Regular", row * 100, f"=C{row}*2"])
+    worksheet["B10"] = "调整项"
+    worksheet["D10"] = "=C10*3" if fault == "formula" else None
+    path = tmp_path / f"secondary-row-{fault}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == rule_id and finding.location == "D10"
+    )
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "D10" for patch in scan.patches)
+
+
+def test_visually_marked_blank_formula_gap_is_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Calculated"])
+    for row in range(2, 22):
+        worksheet.append([f"Item {row}", f'=A{row}&"-done"'])
+    worksheet["B10"] = None
+    worksheet["B10"].fill = PatternFill("solid", fgColor="FFF2CC")
+    path = tmp_path / "highlighted-blank-formula-gap.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == "WL003_BLANK_IN_FORMULA_BAND" and finding.location == "B10"
+    )
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+def test_summary_label_outside_inferred_region_blocks_numeric_and_style_patches(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["C1"] = "Item"
+    worksheet["D1"] = "Amount"
+    for row in range(2, 22):
+        worksheet[f"C{row}"] = f"R{row}"
+        worksheet[f"D{row}"] = row * 100
+    worksheet["A10"] = "Summary"
+    worksheet["D10"] = "1200"
+    worksheet["D10"].font = Font(bold=True)
+    path = tmp_path / "outside-region-summary.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    findings = {(finding.rule_id, finding.location) for finding in scan.findings}
+    assert ("WL006_NUMERIC_TEXT", "D10") in findings
+    assert ("WL007_STYLE_OUTLIER", "D10") in findings
+    assert not any(patch.cell == "D10" for patch in scan.patches)
+
+
+def test_intentionally_highlighted_row_blocks_content_and_style_patches(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Amount", "Calculated"])
+    for row in range(2, 22):
+        worksheet.append([f"Item {row}", row * 100, f"=B{row}*2"])
+    worksheet["B10"] = "1200"
+    worksheet["C10"] = 999
+    highlight = PatternFill("solid", fgColor="FFF2CC")
+    for cell in worksheet[10]:
+        cell.font = Font(bold=True)
+        cell.fill = highlight
+    path = tmp_path / "highlighted-override-row.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    findings = {(finding.rule_id, finding.location) for finding in scan.findings}
+    assert ("WL004_HARDCODED_VALUE_IN_FORMULA_BAND", "C10") in findings
+    assert ("WL006_NUMERIC_TEXT", "B10") in findings
+    assert ("WL007_STYLE_OUTLIER", "B10") in findings
+    assert not any(patch.cell in {"B10", "C10"} for patch in scan.patches)
+
+
+def test_freeform_only_row_labels_keep_formula_and_style_findings_review_only(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    names = [
+        "Alice",
+        "Bob",
+        "Carol",
+        "Diego",
+        "Eve",
+        "Fatima",
+        "Grace",
+        "Special Case",
+        "Hiro",
+        "Iris",
+        "Jamal",
+        "Kai",
+        "Lina",
+        "Marta",
+        "Nora",
+        "Omar",
+        "Pia",
+        "Quinn",
+        "Ravi",
+        "Sara",
+    ]
+    worksheet.append(["Name", "Amount", "Calculated"])
+    for row, name in enumerate(names, start=2):
+        worksheet.append([name, row * 100, f"=B{row}*2"])
+    worksheet["B9"].font = Font(bold=True)
+    worksheet["C9"] = 999
+    path = tmp_path / "freeform-label-special-case.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    findings = {(finding.rule_id, finding.location) for finding in scan.findings}
+    assert ("WL004_HARDCODED_VALUE_IN_FORMULA_BAND", "C9") in findings
+    assert ("WL007_STYLE_OUTLIER", "B9") in findings
+    assert not any(patch.cell in {"B9", "C9"} for patch in scan.patches)
+
+
 def test_hidden_adjacent_row_suppresses_sum_boundary(tmp_path: Path) -> None:
     workbook = Workbook()
     worksheet = workbook.active
@@ -169,6 +948,73 @@ def test_hidden_adjacent_row_suppresses_sum_boundary(tmp_path: Path) -> None:
     workbook.close()
     scan = scan_workbook(path)
     assert not any(finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY" for finding in scan.findings)
+
+
+def test_sum_boundary_numeric_candidate_is_findings_only(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 10):
+        worksheet.cell(row, 1, f"R{row}")
+        worksheet.cell(row, 2, row * 100)
+    worksheet["A10"] = "Total"
+    worksheet["B10"] = "=SUM(B2:B8)"
+    path = tmp_path / "numeric-boundary-findings-only.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding for finding in scan.findings if finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY"
+    )
+    assert finding.location == "B10"
+    assert finding.evidence.expected == "=SUM(B2:B9)"
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "Subtotal",
+        "Sub-total",
+        "Grand-total",
+        "Total adjustment",
+        "Average",
+        "Mean",
+        "Minimum",
+        "Maximum",
+        "Summary",
+        "小计",
+        "合计金额",
+        "汇总金额",
+        "平均金额",
+        "最大金额",
+        "最小金额",
+        "总金额",
+        "累计金额",
+        "净额",
+        "期末余额",
+    ],
+)
+def test_sum_boundary_subtotal_candidate_is_findings_only(tmp_path: Path, label: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 10):
+        worksheet.cell(row, 2, row * 100)
+    worksheet["A9"] = label
+    worksheet["B10"] = "=SUM(B2:B8)"
+    path = tmp_path / f"subtotal-boundary-{len(label)}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY" and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B10" for patch in scan.patches)
 
 
 def test_sum_boundary_does_not_cross_explicit_sheet_reference(tmp_path: Path) -> None:
@@ -188,19 +1034,27 @@ def test_sum_boundary_does_not_cross_explicit_sheet_reference(tmp_path: Path) ->
     assert not any(finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY" for finding in scan.findings)
 
 
-def test_sum_boundary_requires_literal_numeric_adjacent_cell(tmp_path: Path) -> None:
+def test_sum_boundary_reports_adjacent_formula_without_patch(tmp_path: Path) -> None:
     workbook = Workbook()
     worksheet = workbook.active
     assert worksheet is not None
     for row in range(2, 9):
+        worksheet.cell(row, 1, f"R{row}")
         worksheet.cell(row, 2, row)
+    worksheet["A9"] = "R9"
     worksheet["B9"] = "=1+1"
+    worksheet["A10"] = "Total"
     worksheet["B10"] = "=SUM(B2:B8)"
     path = tmp_path / "formula-adjacent-sum.xlsx"
     workbook.save(path)
     workbook.close()
     scan = scan_workbook(path)
-    assert not any(finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY" for finding in scan.findings)
+    finding = next(
+        finding for finding in scan.findings if finding.rule_id == "WL005_SUSPICIOUS_SUM_BOUNDARY"
+    )
+    assert finding.location == "B10"
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "B10" for patch in scan.patches)
 
 
 def test_scientific_notation_text_is_not_auto_converted(tmp_path: Path) -> None:
@@ -256,6 +1110,130 @@ def test_merged_header_is_not_reported_as_data_body_merge(tmp_path: Path) -> Non
     assert not any(
         finding.rule_id == "WL014_MERGED_CELL_IN_DATA_REGION" for finding in scan.findings
     )
+
+
+def test_merged_non_anchor_formula_gap_is_never_auto_patched(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(4, 12):
+        for column in range(2, 7):
+            worksheet.cell(row, column, row + column)
+    for column in (2, 3, 5, 6):
+        coordinate = worksheet.cell(12, column).coordinate
+        source = worksheet.cell(11, column).coordinate
+        worksheet[coordinate] = f"={source}*2"
+    worksheet.merge_cells("C12:D12")
+    path = tmp_path / "merged-non-anchor.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    finding = next(
+        finding
+        for finding in scan.findings
+        if finding.rule_id == "WL003_BLANK_IN_FORMULA_BAND" and finding.location == "D12"
+    )
+    assert not finding.safe_patch_available
+    assert not any(patch.cell == "D12" for patch in scan.patches)
+
+
+def test_merged_anchor_formula_gap_is_never_auto_patched(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in (2, 3, 5, 6):
+        worksheet[f"B{row}"] = f"=A{row}*2"
+    worksheet.merge_cells("B4:C4")
+    path = tmp_path / "merged-anchor-gap.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL003_BLANK_IN_FORMULA_BAND" and finding.location == "B4"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B4" for patch in scan.patches)
+
+
+def test_merged_anchor_literal_is_never_replaced(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 22):
+        worksheet[f"B{row}"] = f"=A{row}*2"
+    worksheet["B10"] = "Merged note"
+    worksheet.merge_cells("B10:C10")
+    path = tmp_path / "merged-anchor-literal.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL004_HARDCODED_VALUE_IN_FORMULA_BAND" and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "Subtotal",
+        "Sub-total",
+        "Grand-total",
+        "Average",
+        "Mean",
+        "Minimum",
+        "Maximum",
+        "小计",
+        "小计金额",
+        "合计金额",
+        "汇总金额",
+        "平均金额",
+        "最大金额",
+        "最小金额",
+    ],
+)
+def test_summary_row_literal_is_never_replaced(tmp_path: Path, label: str) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 22):
+        worksheet[f"B{row}"] = f"=A{row}*2"
+    worksheet["A10"] = label
+    worksheet["B10"] = 999
+    path = tmp_path / f"summary-literal-{len(label)}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL004_HARDCODED_VALUE_IN_FORMULA_BAND" and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B10" for patch in scan.patches)
+
+
+def test_hidden_literal_is_never_replaced(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(2, 22):
+        worksheet[f"B{row}"] = f"=A{row}*2"
+    worksheet["B10"] = 999
+    worksheet.row_dimensions[10].hidden = True
+    path = tmp_path / "hidden-literal.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL004_HARDCODED_VALUE_IN_FORMULA_BAND" and finding.location == "B10"
+        for finding in scan.findings
+    )
+    assert not any(patch.cell == "B10" for patch in scan.patches)
 
 
 def test_all_fifteen_builtin_rule_ids_are_stable(demo_scan: ScanResult, tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "workbooklens"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Release WorkbookLens 2.1.0 with substantially more conservative automatic Excel repair and stronger OOXML preservation.

- Support ordinary worksheets in workbooks containing Chartsheets without changing chart parts.
- Auto-convert numeric text only under explicit measure headers; identifiers, leading zeros, unknown columns, and text-formatted cells remain review-only.
- Refuse automatic repair in merged ranges, summary/subtotal rows, protected or non-visible worksheets, and hidden rows or columns.
- Require stable peer-row text and visual patterns before formula or style repair.
- Preserve number format, protection, quote-prefix, and pivot-button semantics during style repair.
- Keep suspicious SUM boundaries review-only.
- Align security-support and GitHub-only publication documentation, and make Twine validation strict.

## Safety and compatibility

- [x] Source workbooks are never overwritten.
- [x] Unsupported or ambiguous cases fail closed.
- [x] OOXML parts outside the declared change set remain preserved.
- [x] Existing JSON schemas and rule IDs remain compatible with 2.0.0.
- [x] Release artifacts exclude workbooks, credentials, environments, caches, and bytecode.

## Verification

- 256 tests passed with 84.66% coverage.
- Ruff formatting/linting, strict Mypy, and lock validation passed.
- Five new complex-workbook regression cases passed 5/5.
- Visual verification passed 35/35 rendered images and all 10 before/after comparisons.
- Findings changed from 28 to 24 through four explicitly authorized patches, with zero secondary or unauthorized patches.
- Strict Twine validation, artifact-content auditing, fresh-wheel installation, CLI smoke tests, and the complete demo passed.
- Final wheel SHA-256: `8845C6826D1B1075A3F13407EE7A9AF682538A3ECD252360E4076A8A8462FC1D`
- Final sdist SHA-256: `D5CDD4CEDD291EA2E7DF790E72A326179B043F0F6C07C80963E807BD9072C8E0`

## Publication scope

This release is GitHub-only. It does not publish to PyPI and does not include a provenance attestation; SHA-256 checksums will be attached to the GitHub Release.
