### PR TITLE
[codex] Release WorkbookLens 2.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: version
     attributes:
       label: WorkbookLens version or commit
-      placeholder: 2.1.0 or a commit SHA
+      placeholder: 2.2.0 or a commit SHA
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - run: uv lock --check
       - run: uv build --out-dir dist
       - run: uvx --from twine twine check --strict dist/*
-      - run: python scripts/check_release_artifacts.py dist --version 2.1.0
+      - run: python scripts/check_release_artifacts.py dist --version 2.2.0
       - uses: actions/upload-artifact@v7
         with:
           name: workbooklens-distributions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,13 @@ jobs:
       - run: uv run python -m pytest -q
       - run: uv build --out-dir dist
       - run: uvx --from twine twine check --strict dist/*
-      - run: python scripts/check_release_artifacts.py dist --version 2.1.0
+      - run: python scripts/check_release_artifacts.py dist --version 2.2.0
       - name: Create checksums
-        run: sha256sum dist/* > SHA256SUMS
+        working-directory: dist
+        run: sha256sum workbooklens-*.whl workbooklens-*.tar.gz > ../SHA256SUMS
       - uses: actions/upload-artifact@v7
         with:
-          name: workbooklens-release-candidate-${{ github.ref_name }}
+          name: workbooklens-release-candidate-${{ github.run_id }}
           path: |
             dist
             SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .tools/
 .artifacts/
 .pytest_cache/
+/.pytest-tmp*/
 .mypy_cache/
 .ruff_cache/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,91 @@
 
 All notable changes are documented here. WorkbookLens follows Semantic Versioning.
 
+## [2.2.0] - 2026-08-22
+
+### Added
+
+- Add `WL016_TEXT_DISPLAY_RISK` for deterministic detection of vertically clipped wrapped or
+  multiline text and horizontally blocked overflow. Repeated overflow can propose a bounded column
+  width; local overflow uses an atomic wrap-and-row-height group.
+- Add `WL017_BORDER_EDGE_INCONSISTENCY` with visual shared-edge semantics. A border stored on either
+  adjoining cell is treated as present. Dense rectangular tables also detect completely borderless
+  internal holes and missing perimeter edges; reviewed repairs require at least 95% peer consensus.
+- Add `WL018_USED_RANGE_INFLATION` for separated format-only tails. Proposed cleanup enumerates the
+  exact blank styled cells and empty row records instead of clearing a rectangular range.
+- Add `WL019_IDENTIFIER_SCIENTIFIC_NOTATION` for long integers under identifier-like headers.
+  Ten- and eleven-digit values can receive a font-aware width-only proposal that preserves their
+  stored numeric value and type. General-formatted values of 12-15 digits remain findings-only
+  because Excel can force scientific notation regardless of column width; longer values remain
+  findings-only because their original precision cannot be recovered safely.
+- Add `WL020_SAVED_VIEW_OFF_CONTENT` for visible sheets saved below or right of their first content,
+  or at a zoom unlikely to show a compact sheet's full estimated width and height in a typical
+  desktop window. Reviewed repairs can reset the top-left cell and reduce excessive zoom while
+  accounting for earlier width/height proposals. Zoom-only repairs preserve an unshifted frozen pane;
+  shifted frozen panes and split panes remain findings-only.
+- Add `WL021_WHITESPACE_ONLY_TAIL` for connected literal-space cells beyond the visible layout
+  envelope. Reviewed cleanup removes default-style nodes, clears only the value of styled nodes, and
+  preserves their style IDs, fonts, alignment, protection, and custom row dimensions.
+- Record declared/content dimensions, explicit row heights, column widths, saved top-left cells, and
+  zoom in snapshots and semantic diffs. Large format-tail removals are summarized instead of emitted
+  as hundreds of blank-cell style changes.
+
+### Changed
+
+- Classify column width, row height, alignment, saved-view, edge-border, and exact-tail
+  operations as `layout_review`. They are always `safe=false`, are excluded from `--safe-only`, and
+  require explicit patch selection plus `--accept-layout-risk` at confidence 0.95 or greater.
+- Close related wrap/height operations into atomic groups so a wrapped cell cannot be applied without
+  the row-height change needed to display it.
+- Extend direct OOXML patching to reviewed row, column, alignment, text, view, border-edge, and
+  format-tail changes without saving the whole package through a spreadsheet application.
+- Preserve identifier value semantics in `WL019`; the low-level text-replacement primitive is not
+  proposed by this rule and requests formula recalculation if used by another reviewed workflow.
+- Size identifier columns with the cell font, include every newly wrapped cell in its atomic row
+  height, and treat hidden columns as zero-width when checking natural text overflow.
+- Detect peer-consensus border gaps in styled blank table cells, preserve merged-range extents during
+  exact UsedRange-tail cleanup, include visible empty border/fill templates in view fitting, and report
+  compact sheets that cannot fit above the automatic 50% zoom safety floor instead of silently
+  treating them as acceptable.
+- Treat single-row merged text as bounded by its merge, retain saved zoom above 100% when the content
+  still fits, include full merged extents and visible row heights in two-dimensional viewport
+  estimates, include prior row-height and column-width proposals in the final fit, preserve frozen-pane
+  XML during zoom-only repair, and coalesce same-column width proposals to their largest sufficient
+  value.
+- Require a materialized internal peer before proposing a shared border edge, reject conflicting
+  duplicate patch identities, and preserve intentional custom-height rows during both formatting-
+  tail and whitespace-tail cleanup.
+- Keep text findings review-only when wrapping would exceed Excel's maximum row height, avoid
+  snapshot-side creation of default row dimensions, and reject an applied patch when the same rule
+  still reports the targeted sheet and cell under a changed finding identity.
+- Show safe and layout-review counts in CLI plans and require a separate layout-risk confirmation in
+  the loopback web UI.
+
+### Security
+
+- Harden the loopback web UI with exact Host validation, Origin/Referer checks, an HttpOnly
+  SameSite CSRF cookie plus form token, restrictive browser headers, and declared and streaming
+  request-body limits enforced before multipart/form parsing.
+- Bind layout patches to row, column, view, or exact-tail fingerprints and revalidate them against a
+  fresh canonical scan before writing.
+- Make format-tail cleanup fail closed on formulas, defined names, tables, validation and conditional
+  formatting ranges, hyperlinks, comments, page breaks, drawing anchors, hidden or outlined rows,
+  unsupported row metadata, and other intersecting worksheet structures.
+- Apply the same reference checks to whitespace-tail removal and reject rich strings, formulas,
+  dynamic `INDIRECT`/`OFFSET` references, metadata-bearing cells, and any stale dimension or layout
+  fingerprint.
+- Continue to write a new output file, enforce the changed-part allowlist, reopen with two readers,
+  rescan, and delete partial output after validation failure.
+
+### Compatibility
+
+- The scan-report schema remains version 2, while the patch-plan schema advances from version 1 to 2.
+  Existing rule IDs retain their stable identities. Consumers that exhaustively enumerate rules,
+  patch kinds, risk values, or snapshot fields must accept the new version-2 members.
+- Repair plans remain version-bound and source-bound; regenerate a 2.1 plan with WorkbookLens 2.2
+  before applying it.
+- `.xlsm` remains read-only, and `.xls`, `.xlsb`, `.ods`, and Google Sheets remain unsupported.
+
 ## [2.1.0] - 2026-08-20
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ uv run python -m pytest -q
 uv run workbooklens demo --out .artifacts/demo
 uv build --out-dir dist
 uvx --from twine twine check --strict dist/*
-python scripts/check_release_artifacts.py dist --version 2.1.0
+python scripts/check_release_artifacts.py dist --version 2.2.0
 ~~~
 
 Review for unsafe ZIP handling, unbounded memory/ranges, inaccurate documentation, source rewrites,

--- a/README.md
+++ b/README.md
@@ -3,14 +3,48 @@
 **Deterministic linting, regression testing, semantic diffing, and conservative repair for
 Excel workbooks.**
 
-WorkbookLens 2.1 works locally without Microsoft Excel, LibreOffice, an AI key, or a cloud service.
+WorkbookLens 2.2 works locally without Microsoft Excel, LibreOffice, an AI key, or a cloud service.
 It does not calculate formulas, execute VBA, open embedded objects, or fetch external links.
 .xlsx files support scan, test, diff, and safe-copy repair; .xlsm files remain read-only.
 
 > **Release status:** GitHub Releases are authoritative for source archives and attached artifacts.
-> Version 2.1.0 may not be published to [PyPI](https://pypi.org/project/workbooklens/); use the
-> source-install instructions below unless PyPI explicitly lists that version. Do not assume pipx
-> or uvx can install a GitHub-only release.
+> Version 2.2.0 may not be published to [PyPI](https://pypi.org/project/workbooklens/); use the
+> downloaded wheel or source checkout instructions below unless PyPI explicitly lists that version.
+> Do not assume pipx or uvx can install a GitHub-only release by package name.
+
+## What is new in 2.2
+
+- Layout-aware snapshots and semantic diffs now record declared/content dimensions, explicit row
+  heights, column widths, and saved worksheet views.
+- `WL016_TEXT_DISPLAY_RISK` detects likely clipped wrapped text and blocked horizontal overflow. It
+  can propose bounded row-height, wrap, or repeated-column-width changes.
+- `WL017_BORDER_EDGE_INCONSISTENCY` treats either side of a shared cell edge as visually present,
+  reducing false positives. It also detects fully borderless holes and missing outer edges inside a
+  dense rectangular table, and proposes only edges supported by at least 95% peer consensus.
+- `WL018_USED_RANGE_INFLATION` identifies separated, format-only tails and can remove only the
+  enumerated blank styled cells and empty row records after reference and structure checks.
+- `WL019_IDENTIFIER_SCIENTIFIC_NOTATION` detects long numeric identifiers under identifier-like
+  headers. Ten- and eleven-digit values can receive a font-aware width-only proposal that preserves
+  the stored numeric value and type. General-formatted values of 12-15 digits remain findings-only
+  because Excel can keep scientific notation even in a wide column; longer values may already have
+  lost precision.
+- `WL020_SAVED_VIEW_OFF_CONTENT` detects sheets saved with their first content scrolled away or at a
+  zoom unlikely to show a compact sheet's full content width and height in a typical desktop window.
+  A reviewed repair can restore the first visible content cell and lower the saved zoom only when the
+  saved zoom actually exceeds the two-dimensional estimated fit. Merged content contributes its full
+  extent, visible border/fill templates count toward the layout, and earlier width/height proposals are
+  included in the estimate. A pure zoom repair may preserve an unshifted frozen pane byte-for-byte;
+  shifted frozen panes and split panes remain findings-only.
+- `WL021_WHITESPACE_ONLY_TAIL` detects connected literal-space cells outside the visible layout
+  envelope. Its reviewed cleanup deletes only default-style nodes; styled cells are cleared while
+  their font, alignment, protection, style ID, and custom blank-row heights are preserved. Referenced
+  or structurally significant targets are refused.
+- Single-row merged titles are treated as bounded display regions, same-column width requests are
+  coalesced to the largest sufficient proposal, and border repair is limited to genuine internal
+  shared edges with materialized peers.
+- Layout-changing proposals are labeled `layout_review`, excluded from `--safe-only`, and require
+  explicit patch selection plus `--accept-layout-risk`. Related wrap/height changes form atomic
+  groups and cannot be applied partially.
 
 ## What is new in 2.1
 
@@ -39,6 +73,45 @@ It does not calculate formulas, execute VBA, open embedded objects, or fetch ext
 - CI tests Python 3.11–3.14 on Linux, Windows, and macOS, then installs the built wheel in fresh
   environments.
 
+## Install the downloaded local package
+
+The `.whl` attached to the GitHub Release is a local Python application package, not a hosted
+upload service. Workbook processing stays on the user's computer. Installing the wheel may contact
+the configured Python package index once to obtain dependencies; scanning, planning, repair, diff,
+and the loopback web UI do not upload workbooks.
+
+Download `workbooklens-2.2.0-py3-none-any.whl`, `workbooklens-2.2.0.tar.gz`, and
+`SHA256SUMS` from the official
+[GitHub Release](https://github.com/chenweixin123/workbooklens/releases/tag/v2.2.0), verify the
+checksum, and install it with Python 3.11+ and `uv`.
+
+### PowerShell
+
+~~~powershell
+Get-Content .\SHA256SUMS
+(Get-FileHash .\workbooklens-2.2.0-py3-none-any.whl -Algorithm SHA256).Hash
+uv tool install .\workbooklens-2.2.0-py3-none-any.whl
+workbooklens --version
+workbooklens serve --port 8765
+~~~
+
+### Bash
+
+~~~bash
+sha256sum -c SHA256SUMS
+uv tool install ./workbooklens-2.2.0-py3-none-any.whl
+workbooklens --version
+workbooklens serve --port 8765
+~~~
+
+Then open `http://127.0.0.1:8765/`. The browser page and temporary upload directory are local to
+that process. Sensitive workbooks should use the CLI or this loopback UI rather than a hosted CI
+runner.
+
+WorkbookLens 2.2.0 does not provide a signed standalone Windows `.exe` or installer. Do not install
+unofficial repackaged executables. A separately validated Windows portable build can be added in a
+future patch release without changing the local-processing model.
+
 ## Install from this source checkout
 
 WorkbookLens requires Python 3.11 or newer and [uv](https://docs.astral.sh/uv/).
@@ -63,11 +136,11 @@ uv run workbooklens --version
 uv run workbooklens demo --out .artifacts/demo
 ~~~
 
-If PyPI lists version 2.1.0, isolated installation is:
+If PyPI lists version 2.2.0, isolated installation is:
 
 ~~~bash
-uvx --from workbooklens==2.1.0 workbooklens --help
-pipx install workbooklens==2.1.0
+uvx --from workbooklens==2.2.0 workbooklens --help
+pipx install workbooklens==2.2.0
 ~~~
 
 ## Core workflows
@@ -89,6 +162,9 @@ workbooklens scan INPUT.xlsx --source-scope models/INPUT.xlsx --baseline previou
 workbooklens plan INPUT.xlsx --config workbooklens.yml --out repair-plan.json
 workbooklens apply INPUT.xlsx repair-plan.json --patch-id patch-0123456789abcdef --out INPUT.fixed.xlsx
 workbooklens apply INPUT.xlsx repair-plan.json --safe-only --out INPUT.fixed.xlsx
+
+# Apply an explicitly reviewed layout patch or atomic layout group
+workbooklens apply INPUT.xlsx repair-plan.json --patch-id patch-fedcba9876543210 --accept-layout-risk --out INPUT.layout-fixed.xlsx
 
 # Semantic before/after comparison
 workbooklens diff BEFORE.xlsx AFTER.xlsx --out diff.html
@@ -142,7 +218,7 @@ confidentiality as the input workbook.
 
 ## GitHub Action
 
-After the v2.1.0 tag exists:
+After the v2.2.0 tag exists:
 
 ~~~yaml
 permissions:
@@ -154,7 +230,7 @@ steps:
     with:
       fetch-depth: 0
 
-  - uses: chenweixin123/workbooklens@v2.1.0
+  - uses: chenweixin123/workbooklens@v2.2.0
     with:
       mode: scan
       path: workbooks
@@ -168,7 +244,7 @@ steps:
 Assertion mode requires config and deliberately rejects baseline/new-only:
 
 ~~~yaml
-- uses: chenweixin123/workbooklens@v2.1.0
+- uses: chenweixin123/workbooklens@v2.2.0
   with:
     mode: test
     path: workbooks
@@ -183,9 +259,14 @@ by the Action.
 
 ## Repair safety
 
-Repair plans bind every operation to the complete source SHA-256 and a target-cell fingerprint.
-Before writing, the engine rescans the source and requires the serialized plan to match the canonical
-plan field-for-field; only canonical operations marked safe with confidence at least 0.95 execute.
+Repair plans bind every operation to the complete source SHA-256 and target preconditions. Before
+writing, the engine rescans the source and requires the serialized plan to match the canonical plan
+field-for-field. Ordinary operations execute only when marked safe with confidence at least 0.95.
+Layout-changing operations are always `safe=false` with risk `layout_review`; `--safe-only` cannot
+select them. They require one or more explicit `--patch-id` selections, confidence at least 0.95,
+and `--accept-layout-risk`. This opt-in never authorizes any other unsafe operation. Selecting one
+member of an atomic group selects the complete group.
+
 Automatic operations are withheld for merged targets, summary rows, non-visible sheets, hidden rows
 or columns, and protected worksheets. The low-level patcher independently rechecks protection and
 visibility so an edited or stale plan cannot bypass the scanner's safety boundary. Numeric conversion
@@ -200,6 +281,9 @@ without a dominant template causes automatic repair to be withheld.
 The engine writes a new OOXML package directly, verifies the exact changed-part allowlist, reopens
 the result, rescans it, and removes partial output after validation failure. Formula edits remove
 stale caches and request Excel recalculation; WorkbookLens never claims to have calculated the result.
+Layout repairs additionally verify row, column, view, or exact-tail fingerprints. Formatting-tail
+cleanup fails closed when an authorized cell or row intersects formulas, names, table or validation
+ranges, comments, links, page breaks, drawing anchors, or other guarded worksheet structures.
 
 ## Security boundaries
 
@@ -219,6 +303,15 @@ workbook to a public issue.
   not proof that the adjacent row belongs in the aggregate.
 - Structured references can be scanned but are not translated for repair.
 - Region inference is conservative and can miss sparse or unusually formatted tables.
+- Text width and row-height estimates are deterministic approximations, not Excel's rendering
+  engine. Results can vary with fonts, printer metrics, DPI, locale, and application version; review
+  layout changes in the target spreadsheet application.
+- A saved zoom reset is a conservative opening view, not a guarantee that every column fits every
+  screen. Frozen or split panes are preserved and block automatic saved-view repair.
+- Border repair requires strong local peer consensus and changes one reviewed edge only; irregular
+  tables can remain findings-only or undetected.
+- Format-tail cleanup ignores broad column styling by itself and refuses ambiguous references or
+  structures. It is not a general "reset UsedRange" command.
 - Rule and region detection are deterministic heuristics. Passing a scan does not prove that every
   real-world workbook error has been found, and a finding does not by itself prove the proposed
   business meaning.
@@ -236,7 +329,7 @@ uv run mypy src
 uv run python -m pytest -q
 uv build --out-dir dist
 uvx --from twine twine check --strict dist/*
-python scripts/check_release_artifacts.py dist --version 2.1.0
+python scripts/check_release_artifacts.py dist --version 2.2.0
 ~~~
 
 See [CONTRIBUTING.md](CONTRIBUTING.md), [the architecture guide](docs/architecture.md),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,22 +32,24 @@ reproducer.
 
 | Version | Security support |
 |---|---|
-| 2.1.x | Supported |
-| 2.0.x and earlier | Upgrade required |
+| 2.2.x | Supported |
+| 2.1.x and earlier | Upgrade required |
 
 Security fixes land on main and are included in the next supported patch release. A GitHub
 Security Advisory may remain private until users have an upgrade path.
 
 ## Security model
 
-WorkbookLens 2.1 does not execute formulas, VBA, embedded objects, or external links. It rejects
+WorkbookLens 2.2 does not execute formulas, VBA, embedded objects, or external links. It rejects
 packages that exceed entry, compressed/uncompressed size, compression-ratio, member-path,
 relationship, or XML limits. DTDs and entities are forbidden. .xlsm remains read-only.
 
 Repairs require a matching source hash, matching target fingerprints, explicit safe patches, an
 exact changed-part allowlist, successful reopen, and a clean post-repair scan. Partial output is
-removed on failure. The web server binds to 127.0.0.1 and stores uploads in a process-owned
-temporary directory.
+removed on failure. The web server binds to 127.0.0.1, rejects non-loopback Host headers and
+cross-origin or invalid-token form submissions, and sends restrictive browser security headers.
+Uploads stay in a process-owned temporary directory that is removed on normal shutdown; an abrupt
+process or operating-system stop can leave files until manual or operating-system cleanup.
 
 Release artifacts are built from an explicit allowlist and audited for unexpected roots,
 environments, caches, bytecode, secret-like files, and oversized members. These controls reduce

--- a/docs/adr/0001-direct-ooxml-patching.md
+++ b/docs/adr/0001-direct-ooxml-patching.md
@@ -14,13 +14,28 @@ what it declares.
 ## Decision
 
 Repaired workbooks are written by a dedicated ZIP/XML engine. It copies every input entry and
-replaces only worksheet parts containing selected cells. If any formula changes, it also updates
-workbook calculation metadata, removes the changed formula's stale cached value, and requests full
-recalculation on next open.
+replaces only worksheet parts containing selected operations. A reviewed alignment, text-storage,
+or border-edge operation may also add an exact style record in `xl/styles.xml`. If any formula
+changes, the engine updates workbook calculation metadata, removes the changed formula's stale
+cached value, and requests full recalculation on next open.
 
-Before replacement, the engine validates the source and cell fingerprints. After replacement, it
-compares every package entry, rejects an unexpected changed/added/removed part, reopens the output,
-checks requested cell semantics, rescans findings, and deletes the output on failure.
+Before replacement, the engine validates the source and cell fingerprints. Layout operations also
+carry row, column, saved-view, or exact-tail fingerprints. Column width, row height, wrapping,
+shrink-to-fit, text storage, saved view, edge-border, and format-tail operations are classified as
+`layout_review`: they are never eligible for `--safe-only` and require explicit patch selection plus
+`--accept-layout-risk`. Related wrap/height operations use atomic groups. The identifier-display rule
+does not rewrite numeric values as text; it proposes a font-aware width-only repair for ten- and
+eleven-digit values so COUNT, SUM, MATCH, validation, and pivot semantics remain unchanged. Longer
+General-formatted identifiers remain review-only when width alone cannot guarantee literal display.
+
+Exact format-tail cleanup is not a rectangular clear or a generic UsedRange reset. It removes only
+enumerated blank styled cells and empty row records and fails closed when they intersect worksheet
+formulas, defined names, tables, validation or formatting ranges, hyperlinks, comments, page breaks,
+drawing anchors, or unsupported row metadata.
+
+After replacement, the engine compares every package entry, rejects an unexpected changed, added,
+or removed part, reopens the output, checks requested cell and layout semantics, rescans findings,
+and deletes the output on failure.
 
 ## Consequences
 
@@ -29,16 +44,20 @@ Benefits:
 - unknown and unrelated package content is preserved;
 - changes are reviewable at both semantic and package-part levels;
 - stale plans and ambiguous formula types fail closed;
+- layout risk is separated from confidence and requires an explicit second opt-in;
+- atomic groups prevent partial repairs that would introduce a new clipping or display defect;
 - no Office installation is required.
 
 Costs:
 
 - the patch surface stays deliberately small;
-- XML namespace, cell-order, dimension, shared-formula, and recalculation rules require focused
-  tests;
+- XML namespace, cell-order, dimension, style-table, shared-formula, view, and recalculation rules
+  require focused tests;
 - unsupported formula modes are reported but cannot be auto-repaired;
+- deterministic text measurement and saved zoom are conservative estimates and require review in
+  the target spreadsheet application;
 - changed worksheet XML is reserialized, so byte identity is guaranteed for untouched parts, not
-  for the modified worksheet part itself.
+  for a modified worksheet or styles part itself.
 
 ## Rejected alternatives
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,12 +10,12 @@ recorded but never dereferenced.
 ```mermaid
 flowchart LR
     A["Untrusted .xlsx/.xlsm"] --> B["ZIP and XML safety gate"]
-    B --> C["Read-only semantic snapshot"]
-    C --> D["Region and formula analysis"]
-    D --> E["15-rule registry"]
+    B --> C["Read-only semantic and layout snapshot"]
+    C --> D["Region, formula, and layout analysis"]
+    D --> E["21-rule registry"]
     E --> F["HTML, JSON, SARIF"]
     E --> G["Source-bound patch plan"]
-    G --> H["Selected safe operations"]
+    G --> H["Safe-only or explicitly reviewed layout operations"]
     H --> I["Direct OOXML patch engine"]
     I --> J["Part manifest and reopen"]
     J --> K["Rescan and semantic diff"]
@@ -26,11 +26,14 @@ flowchart LR
 - `models`: strict Pydantic public schemas and enums.
 - `ooxml`: package limits, hardened XML parsing, relationship checks, and direct patching.
 - `snapshot`: sparse extraction of populated/styled cells and workbook structure.
+- `layout`: deterministic text measurement, visual shared-border semantics, content bounds, and
+  format-tail discovery without invoking a spreadsheet renderer.
 - `formulas`: non-executing A1 token analysis, R1C1-like signatures, and conservative translation.
 - `regions`: connected dense regions and formula bands with bounded gaps.
 - `rules`: plugin interface, registry, and the version-2 built-in catalog.
-- `repair`: deterministic plans, preconditions, direct XML operations, manifests, and validation.
-- `diff`: semantic comparison independent of ZIP serialization.
+- `repair`: deterministic plans, cell/layout preconditions, atomic groups, direct XML operations,
+  manifests, and validation.
+- `diff`: semantic and layout comparison independent of ZIP serialization.
 - `testing`: bounded YAML assertions, not a general formula evaluator.
 - `reports`: self-contained HTML/JSON/SARIF serialization.
 - `web`: loopback-only FastAPI workflow backed by process-owned temporary storage.
@@ -39,28 +42,39 @@ flowchart LR
 ## Data flow and invariants
 
 The scanner holds one in-memory `openpyxl` workbook only while rules run, then closes it. Rules may
-propose declarative operations but do not write files. Finding and patch IDs are hashes of stable
-semantic inputs rather than list positions.
+propose declarative operations but do not write files. The snapshot distinguishes populated-content
+bounds from the worksheet's declared dimension and records explicit row heights, column widths, and
+saved views. Finding, patch, and atomic-group IDs are hashes of stable semantic inputs rather than
+list positions.
 
 The repair engine checks these invariants:
 
 1. input SHA-256 equals the plan source hash;
 2. each target semantic fingerprint equals its precondition;
-3. each selected operation is marked safe and has confidence at least 0.95;
-4. `.xlsm` is never written;
-5. target/source cells do not use unsupported formula modes;
-6. changed package parts equal the exact expected part set;
-7. unchanged entry contents compare byte-for-byte;
-8. output reopens through two readers and matches every requested semantic value;
-9. source SHA-256 remains unchanged;
-10. a rescan introduces no error- or critical-level finding.
+3. every selected operation has confidence at least 0.95 and is either safe-only eligible or an
+   explicitly accepted `layout_review` operation;
+4. `--safe-only` excludes every layout-changing operation, and layout consent never authorizes a
+   different unsafe risk class;
+5. each atomic group is selected and applied in full;
+6. target/source cell fingerprints and applicable row, column, view, or exact-tail fingerprints
+   still match;
+7. `.xlsm` is never written;
+8. target/source cells do not use unsupported formula modes;
+9. changed package parts equal the exact expected part set;
+10. unchanged entry contents compare byte-for-byte;
+11. output reopens through two readers and matches every requested semantic or layout value;
+12. source SHA-256 remains unchanged;
+13. a rescan introduces no error- or critical-level finding.
 
 ## Resource model
 
 The safety layer performs central-directory checks before decompression and reads XML with a
-per-part bound. Snapshot/region logic iterates the sparse cell store rather than trusting an OOXML
-dimension such as `A1:XFD1048576`. YAML assertions independently cap expanded ranges at 100,000
-cells. Web uploads stream in 1 MiB chunks and stop at the configured compressed-file limit.
+per-part bound. Snapshot, region, and layout logic iterate the sparse cell store rather than trusting
+an OOXML dimension such as `A1:XFD1048576`. Format-tail cleanup authorizes bounded exact cell and row
+lists, then rejects intersections with formulas, names, tables, validations, comments, hyperlinks,
+page breaks, drawings, or unsupported row metadata. YAML assertions independently cap expanded
+ranges at 100,000 cells. Web uploads stream in 1 MiB chunks and stop at the configured compressed-file
+limit.
 
 ## Extension model
 

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -17,5 +17,16 @@ fail merely because findings exist unless --fail-on is supplied. With --baseline
 only active new findings participate in the threshold. The test command exits 1 when a configured
 gate fails.
 
+`apply --safe-only` selects only operations marked safe with confidence at least 0.95 and always
+excludes `layout_review` operations. A layout operation requires explicit `--patch-id` selection and
+`--accept-layout-risk`; the flag never enables another unsafe operation. Selecting one member of an
+atomic repair group expands the selection to the complete group. Missing layout consent, a patch
+below the confidence threshold, an incomplete group presented to the low-level patcher, an unknown
+patch ID, or incompatible selection flags exits with code 2 before an output workbook is written.
+
+A source hash or cell/layout fingerprint mismatch exits with code 4. An OOXML structure that makes a
+reviewed change unsafe to perform, or a post-write semantic/layout mismatch, exits with code 5 and
+the partial output is removed.
+
 The composite Action records the aggregate code in its exit-code output after writing the manifest
 and report-path outputs. This lets artifact upload run before the final enforcement step.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -17,6 +17,12 @@
 - [ ] Charts, drawings, images, relationships, themes, and unknown fixtures remain byte-identical.
 - [ ] Shared, array, data-table, dynamic-array, stale-plan, and malformed inputs fail closed.
 - [ ] Formula edits remove caches and request recalculation without claiming it occurred.
+- [ ] `--safe-only` excludes every `layout_review` patch; explicit layout selection requires
+  `--accept-layout-risk`, confidence at least 0.95, and complete atomic groups.
+- [ ] Row heights, column widths, wrapping, width-only identifier display, saved views, edge-only borders, and
+  exact format-tail cleanup are represented accurately in scan, apply, rescan, and semantic diff.
+- [ ] Format-tail cleanup refuses formulas, names, tables, guarded ranges, links, comments, page
+  breaks, drawings, hidden/outlined rows, and unsupported row metadata.
 
 ## Security and supply chain
 
@@ -33,10 +39,12 @@
 - [ ] The exact wheel is installed into fresh Linux, Windows, and macOS environments.
 - [ ] workbooklens --version, --help, and demo run from the wheel rather than the source tree.
 - [ ] README Bash and PowerShell commands match a clean checkout.
+- [ ] Representative layout repairs are opened in the target spreadsheet application; text is not
+  clipped, identifiers are exact, the initial viewport is useful, and printer/page layout is reviewed.
 
 ## Release candidate and publication
 
-- [ ] Push v2.1.0; the release-candidate workflow validates the tag, builds distributions,
+- [ ] Push v2.2.0; the release-candidate workflow validates the tag, builds distributions,
   generates SHA256SUMS, and uploads workflow artifacts.
 - [ ] Inspect the downloaded artifacts before external publication.
 - [ ] Record whether the release is GitHub-only or also publishes to PyPI.
@@ -46,4 +54,4 @@
   chenweixin123/workbooklens, then publish only from the validated tag using OIDC; do not add a
   long-lived PyPI token.
 - [ ] If publishing to PyPI, verify the project page, uvx installation, and pipx installation for
-  version 2.1.0.
+  version 2.2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "workbooklens"
-version = "2.1.0"
+version = "2.2.0"
 description = "Local-first linting, testing, semantic diffing, and safe repair for Excel workbooks"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/workbooklens/__init__.py
+++ b/src/workbooklens/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/src/workbooklens/cli.py
+++ b/src/workbooklens/cli.py
@@ -14,7 +14,7 @@ from workbooklens import __version__
 from workbooklens.demo import run_demo
 from workbooklens.diff import compare_workbooks, write_diff_report
 from workbooklens.exceptions import ExitCode, UsageError, WorkbookLensError
-from workbooklens.models import SEVERITY_RANK, Severity
+from workbooklens.models import SEVERITY_RANK, PatchRisk, Severity
 from workbooklens.ooxml.safety import PackageLimits
 from workbooklens.policy import apply_finding_policy, load_baseline, source_scope_for_path
 from workbooklens.repair import apply_patch_plan, build_patch_plan
@@ -182,9 +182,13 @@ def plan(
         )
         patch_plan = build_patch_plan(result)
         write_patch_plan(out, patch_plan)
-        safe_count = sum(patch.safe for patch in patch_plan.patches)
+        safe_count = sum(patch.safe_only_eligible for patch in patch_plan.patches)
+        layout_review_count = sum(
+            patch.risk == PatchRisk.LAYOUT_REVIEW for patch in patch_plan.patches
+        )
         console.print(
-            f"[green]Planned[/green] {len(patch_plan.patches)} patches ({safe_count} safe) → {out}"
+            f"[green]Planned[/green] {len(patch_plan.patches)} patches "
+            f"({safe_count} safe, {layout_review_count} layout review) → {out}"
         )
     except typer.Exit:
         raise
@@ -205,14 +209,21 @@ def apply(
         help="Selected patch ID; repeat for multiple patches.",
     ),
     safe_only: bool = typer.Option(
-        False, "--safe-only", help="Apply every safe patch at confidence ≥0.95."
+        False,
+        "--safe-only",
+        help="Apply every safe patch at confidence ≥0.95; excludes layout-review patches.",
+    ),
+    accept_layout_risk: bool = typer.Option(
+        False,
+        "--accept-layout-risk",
+        help="Allow explicitly selected layout-review patches; never enables other unsafe patches.",
     ),
     config: Path | None = typer.Option(
         None, "--config", help="Optional workbooklens YAML configuration."
     ),
     max_file_mb: int = typer.Option(100, min=1, help="Maximum compressed input size."),
 ) -> None:
-    """Apply explicitly selected safe patches to a validated new workbook copy."""
+    """Apply selected patches to a validated new workbook copy."""
 
     try:
         plan_model = load_patch_plan(repair_plan)
@@ -220,8 +231,9 @@ def apply(
             input_workbook,
             plan_model,
             out,
-            selected_ids=set(patch_id or []),
+            selected_ids=patch_id,
             safe_only=safe_only,
+            accept_layout_risk=accept_layout_risk,
             config=_optional_config(config),
             limits=_limits(max_file_mb),
         )

--- a/src/workbooklens/diff/engine.py
+++ b/src/workbooklens/diff/engine.py
@@ -169,6 +169,41 @@ def _list_change(
         )
 
 
+def _mapping_change(
+    changes: list[StructuralChange],
+    change_type: str,
+    subject_prefix: str,
+    before: dict[str, Any],
+    after: dict[str, Any],
+    importance: Severity = Severity.INFO,
+) -> None:
+    """Record deterministic additions, removals, and value changes in layout maps."""
+
+    for key in sorted(before.keys() | after.keys()):
+        before_value = before.get(key)
+        after_value = after.get(key)
+        if before_value == after_value:
+            continue
+        changes.append(
+            StructuralChange(
+                change_type=change_type,
+                subject=f"{subject_prefix}{key}",
+                before=before_value,
+                after=after_value,
+                importance=importance,
+            )
+        )
+
+
+def _style_only_blank(cell: CellSnapshot | None) -> bool:
+    return bool(
+        cell is not None
+        and cell.formula is None
+        and cell.value is None
+        and _style_fingerprint(cell) != "default"
+    )
+
+
 def compare_snapshots(before: WorkbookSnapshot, after: WorkbookSnapshot) -> WorkbookDiff:
     """Compare two already-extracted snapshots deterministically."""
 
@@ -234,6 +269,60 @@ def compare_snapshots(before: WorkbookSnapshot, after: WorkbookSnapshot) -> Work
                     importance=Severity.WARNING,
                 )
             )
+        if before_sheet.declared_dimension != after_sheet.declared_dimension:
+            structural.append(
+                StructuralChange(
+                    change_type="declared_dimension",
+                    subject=display_name,
+                    before=before_sheet.declared_dimension,
+                    after=after_sheet.declared_dimension,
+                    importance=Severity.INFO,
+                )
+            )
+        if before_sheet.content_dimension != after_sheet.content_dimension:
+            structural.append(
+                StructuralChange(
+                    change_type="content_dimension",
+                    subject=display_name,
+                    before=before_sheet.content_dimension,
+                    after=after_sheet.content_dimension,
+                    importance=Severity.WARNING,
+                )
+            )
+        _mapping_change(
+            structural,
+            "row_height",
+            f"{display_name}!row ",
+            before_sheet.row_heights,
+            after_sheet.row_heights,
+        )
+        _mapping_change(
+            structural,
+            "column_width",
+            f"{display_name}!column ",
+            before_sheet.column_widths,
+            after_sheet.column_widths,
+        )
+        if before_sheet.view_top_left_cell != after_sheet.view_top_left_cell:
+            structural.append(
+                StructuralChange(
+                    change_type="view_top_left_cell",
+                    subject=display_name,
+                    before=before_sheet.view_top_left_cell,
+                    after=after_sheet.view_top_left_cell,
+                    importance=Severity.INFO,
+                )
+            )
+        if before_sheet.view_zoom_scale != after_sheet.view_zoom_scale:
+            structural.append(
+                StructuralChange(
+                    change_type="view_zoom_scale",
+                    subject=display_name,
+                    before=before_sheet.view_zoom_scale,
+                    after=after_sheet.view_zoom_scale,
+                    importance=Severity.INFO,
+                )
+            )
         _list_change(
             structural,
             "merged_range",
@@ -264,7 +353,44 @@ def compare_snapshots(before: WorkbookSnapshot, after: WorkbookSnapshot) -> Work
             before_sheet.data_validations,
             after_sheet.data_validations,
         )
-        for coordinate in sorted(before_sheet.cells.keys() | after_sheet.cells.keys()):
+        all_coordinates = before_sheet.cells.keys() | after_sheet.cells.keys()
+        removed_style_only = {
+            coordinate
+            for coordinate in all_coordinates
+            if _style_only_blank(before_sheet.cells.get(coordinate))
+            and after_sheet.cells.get(coordinate) is None
+        }
+        added_style_only = {
+            coordinate
+            for coordinate in all_coordinates
+            if before_sheet.cells.get(coordinate) is None
+            and _style_only_blank(after_sheet.cells.get(coordinate))
+        }
+        suppressed_style_only: set[str] = set()
+        dimension_changed = before_sheet.declared_dimension != after_sheet.declared_dimension
+        if dimension_changed and len(removed_style_only) >= 16:
+            suppressed_style_only.update(removed_style_only)
+            structural.append(
+                StructuralChange(
+                    change_type="formatting_tail_cells_removed",
+                    subject=display_name,
+                    before=len(removed_style_only),
+                    after=0,
+                    importance=Severity.INFO,
+                )
+            )
+        if dimension_changed and len(added_style_only) >= 16:
+            suppressed_style_only.update(added_style_only)
+            structural.append(
+                StructuralChange(
+                    change_type="formatting_tail_cells_added",
+                    subject=display_name,
+                    before=0,
+                    after=len(added_style_only),
+                    importance=Severity.INFO,
+                )
+            )
+        for coordinate in sorted(all_coordinates - suppressed_style_only):
             cell_changes.extend(
                 _compare_cell(
                     display_name,

--- a/src/workbooklens/layout.py
+++ b/src/workbooklens/layout.py
@@ -1,0 +1,910 @@
+"""Conservative spreadsheet layout measurements used by first-party rules."""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from collections import deque
+from copy import copy
+from dataclasses import dataclass
+from typing import Any
+
+from openpyxl.cell.cell import Cell
+from openpyxl.styles import Border, Side
+from openpyxl.utils.cell import coordinate_to_tuple, get_column_letter
+from openpyxl.worksheet.cell_range import CellRange
+from openpyxl.worksheet.worksheet import Worksheet
+
+from workbooklens.utils import sha256_bytes, stable_json_bytes
+
+DEFAULT_COLUMN_WIDTH = 8.43
+DEFAULT_ROW_HEIGHT = 15.0
+
+
+@dataclass(frozen=True, slots=True)
+class TextMeasurement:
+    """Static estimate of the space required to display one literal text cell."""
+
+    cell: Cell
+    available_width: float
+    required_width: float
+    required_lines: int
+    required_height: float
+    current_height: float
+    merged_range: str | None = None
+
+    @property
+    def width_ratio(self) -> float:
+        return self.required_width / max(self.available_width, 0.1)
+
+
+@dataclass(frozen=True, slots=True)
+class FormattingTail:
+    """One isolated format-only worksheet tail that can be reviewed as a unit."""
+
+    cell_coordinates: tuple[str, ...]
+    cell_ranges: tuple[str, ...]
+    empty_rows: tuple[int, ...]
+    row_ranges: tuple[str, ...]
+    styled_cell_count: int
+    content_min_row: int
+    content_min_column: int
+    content_max_row: int
+    content_max_column: int
+    observed_max_row: int
+    observed_max_column: int
+
+
+@dataclass(frozen=True, slots=True)
+class WhitespaceTail:
+    """Literal whitespace cells outside the visible layout envelope."""
+
+    cell_coordinates: tuple[str, ...]
+    cell_ranges: tuple[str, ...]
+    row_ranges: tuple[str, ...]
+    content_min_row: int
+    content_min_column: int
+    content_max_row: int
+    content_max_column: int
+    observed_dimension: str
+    result_dimension: str
+    preserve_style_ids: tuple[tuple[str, int], ...] = ()
+
+
+def _dimension_covering_column(worksheet: Worksheet, column: int) -> Any | None:
+    matches = [
+        dimension
+        for dimension in worksheet.column_dimensions.values()
+        if dimension.min is not None
+        and dimension.max is not None
+        and dimension.min <= column <= dimension.max
+    ]
+    return matches[-1] if matches else None
+
+
+def column_width(worksheet: Worksheet, column: int) -> float:
+    """Return the effective explicit/default Excel width for one column."""
+
+    dimension = _dimension_covering_column(worksheet, column)
+    if dimension is not None and dimension.width is not None:
+        return float(dimension.width)
+    if worksheet.sheet_format.defaultColWidth is not None:
+        return float(worksheet.sheet_format.defaultColWidth)
+    return DEFAULT_COLUMN_WIDTH
+
+
+def row_height(worksheet: Worksheet, row: int) -> float:
+    """Return the effective explicit/default row height in points."""
+
+    dimension = worksheet.row_dimensions.get(row)
+    if dimension is not None and dimension.height is not None:
+        return float(dimension.height)
+    if worksheet.sheet_format.defaultRowHeight is not None:
+        return float(worksheet.sheet_format.defaultRowHeight)
+    return DEFAULT_ROW_HEIGHT
+
+
+def explicit_row_height(worksheet: Worksheet, row: int) -> float | None:
+    """Return a custom row height, or ``None`` when Excel may auto-size it."""
+
+    dimension = worksheet.row_dimensions.get(row)
+    if dimension is None or dimension.height is None:
+        return None
+    return float(dimension.height)
+
+
+def _character_units(character: str) -> float:
+    if character == "\t":
+        return 4.0
+    if character.isspace():
+        return 0.5
+    east_asian_width = unicodedata.east_asian_width(character)
+    if east_asian_width in {"W", "F"}:
+        return 2.0
+    if unicodedata.category(character).startswith("P"):
+        return 0.8
+    return 1.0
+
+
+def text_display_units(text: str) -> float:
+    """Estimate Excel column-width units without depending on a platform font API."""
+
+    return sum(_character_units(character) for character in text)
+
+
+def _font_width_factor(cell: Cell, text: str) -> float:
+    """Return a conservative width multiplier for the cell's visible font."""
+
+    font_size = float(cell.font.sz or 11.0)
+    factor = max(0.7, min(2.5, font_size / 11.0))
+    if any(unicodedata.east_asian_width(character) in {"W", "F"} for character in text):
+        factor *= 1.08
+    if cell.font.bold:
+        factor *= 1.04
+    return factor
+
+
+def estimated_text_width(cell: Cell, text: str) -> float:
+    """Estimate the Excel column width needed to display ``text`` in ``cell``."""
+
+    return text_display_units(text) * _font_width_factor(cell, text) + 1.0
+
+
+def _wrapped_line_count(text: str, capacity: float, font_factor: float) -> int:
+    """Estimate word-aware wrapping while allowing overlong tokens to break."""
+
+    tokens = re.findall(r"\s+|\S+", text)
+    if not tokens:
+        return 1
+    lines = 1
+    used = 0.0
+    pending_space = 0.0
+    for token in tokens:
+        width = text_display_units(token) * font_factor
+        if token.isspace():
+            pending_space += width
+            continue
+        if used > 0.0 and used + pending_space + width > capacity:
+            lines += 1
+            used = 0.0
+            pending_space = 0.0
+        span = pending_space + width
+        if used == 0.0 and span > capacity:
+            occupied_lines = max(1, math.ceil(span / capacity))
+            lines += occupied_lines - 1
+            used = span - (occupied_lines - 1) * capacity
+        else:
+            used += span
+        pending_space = 0.0
+    if pending_space and used > 0.0:
+        lines += max(0, math.ceil((used + pending_space) / capacity) - 1)
+    return lines
+
+
+def _merged_range_for_cell(worksheet: Worksheet, cell: Cell) -> CellRange | None:
+    for merged in worksheet.merged_cells.ranges:
+        if cell.coordinate not in merged:
+            continue
+        return CellRange(str(merged))
+    return None
+
+
+def _available_width(worksheet: Worksheet, cell: Cell) -> tuple[float, str | None]:
+    merged = _merged_range_for_cell(worksheet, cell)
+    if merged is None:
+        return column_width(worksheet, cell.column), None
+    width = sum(
+        column_width(worksheet, column) for column in range(merged.min_col, merged.max_col + 1)
+    )
+    return width, str(merged)
+
+
+def measure_text_cell(
+    worksheet: Worksheet,
+    cell: Cell,
+    *,
+    assume_wrap: bool | None = None,
+) -> TextMeasurement | None:
+    """Estimate literal-text clipping while treating merged non-anchors as non-cells."""
+
+    if cell.data_type == "f" or not isinstance(cell.value, str) or not cell.value.strip():
+        return None
+    if cell.alignment.shrink_to_fit or cell.alignment.text_rotation or cell.alignment.indent:
+        return None
+    merged = _merged_range_for_cell(worksheet, cell)
+    if merged is not None:
+        if cell.row != merged.min_row or cell.column != merged.min_col:
+            return None
+        # A single row-height patch cannot safely size a merge spanning several rows.
+        if merged.max_row > merged.min_row:
+            return None
+    available_width, merged_range = _available_width(worksheet, cell)
+    font_size = float(cell.font.sz or 11.0)
+    font_factor = _font_width_factor(cell, cell.value)
+    logical_lines = cell.value.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    segment_widths = [text_display_units(line) * font_factor for line in logical_lines]
+    required_width = max(segment_widths, default=0.0) + 1.0
+    wrap_text = bool(cell.alignment.wrap_text) if assume_wrap is None else assume_wrap
+    if wrap_text:
+        capacity = max(available_width - 1.0, 1.0)
+        required_lines = sum(
+            _wrapped_line_count(line, capacity, font_factor) for line in logical_lines
+        )
+    else:
+        required_lines = max(1, len(logical_lines))
+    line_height = max(12.0, font_size * 1.25)
+    required_height = required_lines * line_height + 2.0
+    return TextMeasurement(
+        cell=cell,
+        available_width=available_width,
+        required_width=required_width,
+        required_lines=required_lines,
+        required_height=required_height,
+        current_height=row_height(worksheet, cell.row),
+        merged_range=merged_range,
+    )
+
+
+def has_visible_border(cell: Cell) -> bool:
+    """Return whether any cardinal border side is visibly styled."""
+
+    return any(
+        side is not None and side.style is not None
+        for side in (cell.border.left, cell.border.right, cell.border.top, cell.border.bottom)
+    )
+
+
+def _side_signature(side: Side | None) -> tuple[Any, ...]:
+    if side is None:
+        return (None, None)
+    color = side.color
+    color_signature = None
+    if color is not None:
+        color_type = color.type if isinstance(color.type, str) else None
+        rgb = color.rgb if isinstance(color.rgb, str) else None
+        indexed = (
+            color.indexed
+            if isinstance(color.indexed, int) and not isinstance(color.indexed, bool)
+            else None
+        )
+        theme = (
+            color.theme
+            if isinstance(color.theme, int) and not isinstance(color.theme, bool)
+            else None
+        )
+        tint = (
+            float(color.tint)
+            if isinstance(color.tint, (int, float)) and not isinstance(color.tint, bool)
+            else None
+        )
+        auto = color.auto if isinstance(color.auto, bool) else None
+        color_signature = (
+            color_type,
+            rgb,
+            indexed,
+            theme,
+            tint,
+            auto,
+        )
+    return (side.style, color_signature)
+
+
+def border_signature(border: Border) -> tuple[Any, ...]:
+    """Return a deterministic cardinal-border signature."""
+
+    return tuple(
+        _side_signature(side) for side in (border.left, border.right, border.top, border.bottom)
+    )
+
+
+def visual_border_signature(worksheet: Worksheet, cell: Cell) -> tuple[Any, ...]:
+    """Describe visible grid edges, accounting for the adjacent cell's matching side."""
+
+    def choose(primary: Side | None, alternate: Side | None) -> tuple[Any, ...]:
+        if (primary is not None and primary.style is not None) or alternate is None:
+            return _side_signature(primary)
+        return _side_signature(alternate)
+
+    left_peer = worksheet._cells.get((cell.row, cell.column - 1)) if cell.column > 1 else None
+    right_peer = worksheet._cells.get((cell.row, cell.column + 1))
+    top_peer = worksheet._cells.get((cell.row - 1, cell.column)) if cell.row > 1 else None
+    bottom_peer = worksheet._cells.get((cell.row + 1, cell.column))
+    return (
+        choose(
+            cell.border.left,
+            left_peer.border.right if isinstance(left_peer, Cell) else None,
+        ),
+        choose(
+            cell.border.right,
+            right_peer.border.left if isinstance(right_peer, Cell) else None,
+        ),
+        choose(
+            cell.border.top,
+            top_peer.border.bottom if isinstance(top_peer, Cell) else None,
+        ),
+        choose(
+            cell.border.bottom,
+            bottom_peer.border.top if isinstance(bottom_peer, Cell) else None,
+        ),
+    )
+
+
+def border_is_missing_only(observed: tuple[Any, ...], expected: tuple[Any, ...]) -> bool:
+    """Return true when every difference is an absent edge rather than a conflicting edge."""
+
+    missing = False
+    for observed_side, expected_side in zip(observed, expected, strict=True):
+        observed_style = observed_side[0]
+        expected_style = expected_side[0]
+        if observed_side == expected_side:
+            continue
+        if observed_style is None and expected_style is not None:
+            missing = True
+            continue
+        return False
+    return missing
+
+
+def non_border_style_key(cell: Cell) -> tuple[Any, ...]:
+    """Group cells whose semantics and decoration differ, if at all, only by border."""
+
+    return (
+        copy(cell.font),
+        copy(cell.fill),
+        copy(cell.alignment),
+        cell.number_format,
+        copy(cell.protection),
+        bool(cell.quotePrefix),
+        bool(cell.pivotButton),
+    )
+
+
+def _meaningful_cells(worksheet: Worksheet) -> list[Cell]:
+    return [
+        cell
+        for cell in worksheet._cells.values()
+        if isinstance(cell, Cell) and cell.value is not None
+    ]
+
+
+def _connected_components(coordinates: set[tuple[int, int]]) -> list[set[tuple[int, int]]]:
+    components: list[set[tuple[int, int]]] = []
+    remaining = set(coordinates)
+    while remaining:
+        start = remaining.pop()
+        component = {start}
+        queue: deque[tuple[int, int]] = deque([start])
+        while queue:
+            row, column = queue.popleft()
+            for neighbor in (
+                (row - 1, column),
+                (row + 1, column),
+                (row, column - 1),
+                (row, column + 1),
+            ):
+                if neighbor not in remaining:
+                    continue
+                remaining.remove(neighbor)
+                component.add(neighbor)
+                queue.append(neighbor)
+        components.append(component)
+    return components
+
+
+def _ranges_from_numbers(numbers: list[int]) -> tuple[str, ...]:
+    if not numbers:
+        return ()
+    ranges: list[str] = []
+    start = previous = numbers[0]
+    for number in numbers[1:]:
+        if number == previous + 1:
+            previous = number
+            continue
+        ranges.append(str(start) if start == previous else f"{start}:{previous}")
+        start = previous = number
+    ranges.append(str(start) if start == previous else f"{start}:{previous}")
+    return tuple(ranges)
+
+
+def _ranges_from_coordinates(coordinates: set[tuple[int, int]]) -> tuple[str, ...]:
+    """Compress exact coordinates into lossless horizontal A1 runs."""
+
+    by_row: dict[int, list[int]] = {}
+    for row, column in coordinates:
+        by_row.setdefault(row, []).append(column)
+    ranges: list[str] = []
+    for row in sorted(by_row):
+        columns = sorted(by_row[row])
+        start = previous = columns[0]
+        for column in columns[1:]:
+            if column == previous + 1:
+                previous = column
+                continue
+            left = f"{get_column_letter(start)}{row}"
+            right = f"{get_column_letter(previous)}{row}"
+            ranges.append(left if start == previous else f"{left}:{right}")
+            start = previous = column
+        left = f"{get_column_letter(start)}{row}"
+        right = f"{get_column_letter(previous)}{row}"
+        ranges.append(left if start == previous else f"{left}:{right}")
+    return tuple(ranges)
+
+
+def _vertical_ranges_from_coordinates(coordinates: set[tuple[int, int]]) -> tuple[str, ...]:
+    by_column: dict[int, list[int]] = {}
+    for row, column in coordinates:
+        by_column.setdefault(column, []).append(row)
+    ranges: list[str] = []
+    for column in sorted(by_column):
+        rows = sorted(by_column[column])
+        start = previous = rows[0]
+        for row in rows[1:]:
+            if row == previous + 1:
+                previous = row
+                continue
+            top = f"{get_column_letter(column)}{start}"
+            bottom = f"{get_column_letter(column)}{previous}"
+            ranges.append(top if start == previous else f"{top}:{bottom}")
+            start = previous = row
+        top = f"{get_column_letter(column)}{start}"
+        bottom = f"{get_column_letter(column)}{previous}"
+        ranges.append(top if start == previous else f"{top}:{bottom}")
+    return tuple(ranges)
+
+
+def _is_literal_whitespace_cell(cell: Cell) -> bool:
+    value = cell.value
+    return bool(
+        cell.data_type == "s"
+        and isinstance(value, str)
+        and value
+        and not value.strip()
+        and not any(character in "\r\n\t" for character in value)
+        and not cell.quotePrefix
+        and (cell.number_format or "General").strip().casefold() == "general"
+        and cell.comment is None
+        and cell.hyperlink is None
+        and not has_visible_border(cell)
+        and cell.fill.fill_type in {None, "none"}
+    )
+
+
+def _extend_bounds(
+    row_bounds: list[int],
+    column_bounds: list[int],
+    cell_range: CellRange,
+) -> None:
+    row_bounds.extend((cell_range.min_row, cell_range.max_row))
+    column_bounds.extend((cell_range.min_col, cell_range.max_col))
+
+
+def _layout_envelope(worksheet: Worksheet) -> tuple[int, int, int, int] | None:
+    """Return bounds of visible content and intentionally formatted structures."""
+
+    row_bounds: list[int] = []
+    column_bounds: list[int] = []
+    for cell in worksheet._cells.values():
+        if not isinstance(cell, Cell) or _is_literal_whitespace_cell(cell):
+            continue
+        visible_value = cell.value is not None
+        visible_format = has_visible_border(cell) or cell.fill.fill_type not in {None, "none"}
+        if (
+            visible_value
+            or visible_format
+            or cell.comment is not None
+            or cell.hyperlink is not None
+        ):
+            row_bounds.append(cell.row)
+            column_bounds.append(cell.column)
+    for merged in worksheet.merged_cells.ranges:
+        _extend_bounds(row_bounds, column_bounds, CellRange(str(merged)))
+    for table in worksheet.tables.values():
+        _extend_bounds(row_bounds, column_bounds, CellRange(table.ref))
+    if worksheet.auto_filter.ref:
+        _extend_bounds(row_bounds, column_bounds, CellRange(worksheet.auto_filter.ref))
+    if worksheet.data_validations is not None:
+        for validation in worksheet.data_validations.dataValidation:
+            for target in validation.ranges.ranges:
+                _extend_bounds(row_bounds, column_bounds, CellRange(str(target)))
+    for conditional_formatting in worksheet.conditional_formatting:
+        for target in conditional_formatting.sqref.ranges:
+            _extend_bounds(row_bounds, column_bounds, CellRange(str(target)))
+    if not row_bounds or not column_bounds:
+        return None
+    return min(row_bounds), min(column_bounds), max(row_bounds), max(column_bounds)
+
+
+def _dimension_without_cells(
+    worksheet: Worksheet,
+    excluded: set[tuple[int, int]],
+) -> str:
+    row_bounds: list[int] = []
+    column_bounds: list[int] = []
+    for cell in worksheet._cells.values():
+        if not isinstance(cell, Cell) or (cell.row, cell.column) in excluded:
+            continue
+        row_bounds.append(cell.row)
+        column_bounds.append(cell.column)
+    for merged in worksheet.merged_cells.ranges:
+        _extend_bounds(row_bounds, column_bounds, CellRange(str(merged)))
+    if not row_bounds or not column_bounds:
+        return "A1"
+    start = f"{get_column_letter(min(column_bounds))}{min(row_bounds)}"
+    end = f"{get_column_letter(max(column_bounds))}{max(row_bounds)}"
+    return start if start == end else f"{start}:{end}"
+
+
+def _row_is_hidden(worksheet: Worksheet, row: int) -> bool:
+    dimension = worksheet.row_dimensions.get(row)
+    return bool(dimension.hidden) if dimension is not None else False
+
+
+def _column_is_hidden(worksheet: Worksheet, column: int) -> bool:
+    dimension = _dimension_covering_column(worksheet, column)
+    return bool(dimension.hidden) if dimension is not None else False
+
+
+def _row_blocks_formatting_tail(worksheet: Worksheet, row: int) -> bool:
+    dimension = worksheet.row_dimensions.get(row)
+    return bool(
+        dimension is not None
+        and (
+            dimension.height is not None
+            or dimension.hidden
+            or dimension.collapsed
+            or dimension.outlineLevel
+        )
+    )
+
+
+def _column_blocks_formatting_tail(worksheet: Worksheet, column: int) -> bool:
+    dimension = _dimension_covering_column(worksheet, column)
+    return bool(
+        dimension is not None
+        and (dimension.hidden or dimension.collapsed or dimension.outlineLevel)
+    )
+
+
+def find_whitespace_tail(worksheet: Worksheet) -> WhitespaceTail | None:
+    """Find a connected literal-whitespace tail outside the visible layout.
+
+    Default-style cells can be removed entirely. Cells with a non-default style
+    remain part of the worksheet dimension: repair may clear only their literal
+    whitespace value while preserving the complete style record.
+    """
+
+    envelope = _layout_envelope(worksheet)
+    if envelope is None:
+        return None
+    min_row, min_column, max_row, max_column = envelope
+    candidates = {
+        (cell.row, cell.column)
+        for cell in worksheet._cells.values()
+        if isinstance(cell, Cell)
+        and _is_literal_whitespace_cell(cell)
+        and (cell.row > max_row or cell.column > max_column)
+        and not _row_is_hidden(worksheet, cell.row)
+        and not _column_is_hidden(worksheet, cell.column)
+        and not any(cell.coordinate in merged for merged in worksheet.merged_cells.ranges)
+    }
+    if not candidates:
+        return None
+    observed_dimension = worksheet.calculate_dimension()
+    observed_bounds = CellRange(observed_dimension)
+    accepted: set[tuple[int, int]] = set()
+    for component in _connected_components(candidates):
+        touches_outer_edge = any(
+            row == observed_bounds.max_row or column == observed_bounds.max_col
+            for row, column in component
+        )
+        if 3 <= len(component) <= 4_096 and touches_outer_edge:
+            accepted.update(component)
+    if not accepted:
+        return None
+    removable = {
+        (row, column) for row, column in accepted if worksheet._cells[(row, column)].style_id == 0
+    }
+    preserve_style_ids = tuple(
+        (
+            f"{get_column_letter(column)}{row}",
+            worksheet._cells[(row, column)].style_id,
+        )
+        for row, column in sorted(accepted - removable)
+    )
+    result_dimension = _dimension_without_cells(worksheet, removable)
+    if not preserve_style_ids and CellRange(result_dimension).bounds == observed_bounds.bounds:
+        return None
+    return WhitespaceTail(
+        cell_coordinates=tuple(
+            f"{get_column_letter(column)}{row}" for row, column in sorted(accepted)
+        ),
+        cell_ranges=_vertical_ranges_from_coordinates(accepted),
+        row_ranges=(),
+        content_min_row=min_row,
+        content_min_column=min_column,
+        content_max_row=max_row,
+        content_max_column=max_column,
+        observed_dimension=observed_dimension,
+        result_dimension=result_dimension,
+        preserve_style_ids=preserve_style_ids,
+    )
+
+
+def find_formatting_tail(worksheet: Worksheet) -> FormattingTail | None:
+    """Find large disconnected style-only islands that inflate a sheet's used range."""
+
+    meaningful = _meaningful_cells(worksheet)
+    if not meaningful:
+        return None
+    row_bounds = [cell.row for cell in meaningful]
+    column_bounds = [cell.column for cell in meaningful]
+    for merged in worksheet.merged_cells.ranges:
+        row_bounds.extend((merged.min_row, merged.max_row))
+        column_bounds.extend((merged.min_col, merged.max_col))
+    content_min_row = min(row_bounds)
+    content_min_column = min(column_bounds)
+    content_max_row = max(row_bounds)
+    content_max_column = max(column_bounds)
+    styled_blank_coordinates = {
+        (cell.row, cell.column)
+        for cell in worksheet._cells.values()
+        if isinstance(cell, Cell)
+        and cell.value is None
+        and cell.has_style
+        and (cell.column >= content_max_column + 8 or cell.row >= content_max_row + 25)
+    }
+    accepted: list[set[tuple[int, int]]] = []
+    for component in _connected_components(styled_blank_coordinates):
+        if len(component) < 16:
+            continue
+        if any(
+            _row_blocks_formatting_tail(worksheet, row)
+            or _column_blocks_formatting_tail(worksheet, column)
+            for row, column in component
+        ):
+            continue
+        rows = [row for row, _ in component]
+        columns = [column for _, column in component]
+        area = (max(rows) - min(rows) + 1) * (max(columns) - min(columns) + 1)
+        density = len(component) / area
+        separated = min(columns) >= content_max_column + 8 or min(rows) >= content_max_row + 25
+        if density >= 0.5 and separated:
+            accepted.append(component)
+    if not accepted:
+        return None
+    all_coordinates: set[tuple[int, int]] = set()
+    for component in accepted:
+        all_coordinates.update(component)
+    cell_coordinates = tuple(
+        f"{get_column_letter(column)}{row}" for row, column in sorted(all_coordinates)
+    )
+    cell_ranges = _ranges_from_coordinates(all_coordinates)
+    rows_with_cells = {
+        cell.row
+        for cell in worksheet._cells.values()
+        if isinstance(cell, Cell) and cell.value is not None
+    }
+    observed_dimension_rows = sorted(
+        row
+        for row in worksheet.row_dimensions
+        if row > content_max_row and row not in rows_with_cells
+    )
+    empty_dimension_rows = sorted(
+        row
+        for row, dimension in worksheet.row_dimensions.items()
+        if row > content_max_row
+        and row not in rows_with_cells
+        and not dimension.hidden
+        and not dimension.collapsed
+        and dimension.outlineLevel == 0
+        # A custom height can encode intentional whitespace or print layout. Only
+        # style-only row records are safe enough to include in a formatting tail.
+        and dimension.height is None
+        and dimension.has_style
+    )
+    observed_max_row = max(
+        [content_max_row, *observed_dimension_rows, *(row for row, _ in all_coordinates)]
+    )
+    observed_max_column = max([content_max_column, *(column for _, column in all_coordinates)])
+    return FormattingTail(
+        cell_coordinates=cell_coordinates,
+        cell_ranges=cell_ranges,
+        empty_rows=tuple(empty_dimension_rows),
+        row_ranges=_ranges_from_numbers(empty_dimension_rows),
+        styled_cell_count=len(all_coordinates),
+        content_min_row=content_min_row,
+        content_min_column=content_min_column,
+        content_max_row=content_max_row,
+        content_max_column=content_max_column,
+        observed_max_row=observed_max_row,
+        observed_max_column=observed_max_column,
+    )
+
+
+def column_layout_fingerprint(worksheet: Worksheet, column: int) -> str:
+    """Hash every column-dimension field that a width patch is allowed to observe."""
+
+    dimension = _dimension_covering_column(worksheet, column)
+    payload = {
+        "column": column,
+        "effective_width": column_width(worksheet, column),
+        "dimension": None
+        if dimension is None
+        else {
+            "min": dimension.min,
+            "max": dimension.max,
+            "width": dimension.width,
+            "hidden": bool(dimension.hidden),
+            "best_fit": bool(dimension.bestFit),
+            "style_id": dimension.style_id,
+            "outline_level": dimension.outlineLevel,
+            "collapsed": bool(dimension.collapsed),
+        },
+    }
+    return sha256_bytes(stable_json_bytes(payload))
+
+
+def row_layout_fingerprint(worksheet: Worksheet, row: int) -> str:
+    """Hash every row-dimension field that a height patch is allowed to observe."""
+
+    dimension = worksheet.row_dimensions.get(row)
+    payload = {
+        "row": row,
+        "effective_height": row_height(worksheet, row),
+        "dimension": None
+        if dimension is None
+        else {
+            "height": dimension.height,
+            "hidden": bool(dimension.hidden),
+            "style_id": dimension.style_id,
+            "outline_level": dimension.outlineLevel,
+            "collapsed": bool(dimension.collapsed),
+        },
+    }
+    return sha256_bytes(stable_json_bytes(payload))
+
+
+def sheet_view_fingerprint(worksheet: Worksheet) -> str:
+    """Hash saved view state while excluding cell selection coordinates from repair."""
+
+    view = worksheet.sheet_view
+    pane = view.pane
+    payload = {
+        "top_left_cell": view.topLeftCell,
+        "zoom_scale": view.zoomScale,
+        "zoom_scale_normal": view.zoomScaleNormal,
+        "zoom_scale_page_layout": view.zoomScalePageLayoutView,
+        "zoom_scale_sheet_layout": view.zoomScaleSheetLayoutView,
+        "view": view.view,
+        "show_grid_lines": view.showGridLines,
+        "pane": None
+        if pane is None
+        else {
+            "state": pane.state,
+            "top_left_cell": pane.topLeftCell,
+            "x_split": pane.xSplit,
+            "y_split": pane.ySplit,
+            "active_pane": pane.activePane,
+        },
+    }
+    return sha256_bytes(stable_json_bytes(payload))
+
+
+def tail_layout_fingerprint(worksheet: Worksheet, tail: FormattingTail) -> str:
+    """Hash the exact format-only cells and empty row dimensions proposed for removal."""
+
+    cells: list[dict[str, Any]] = []
+    for coordinate in tail.cell_coordinates:
+        target = CellRange(coordinate)
+        row = target.min_row
+        column = target.min_col
+        cell = worksheet._cells.get((row, column))
+        cells.append(
+            {
+                "row": row,
+                "column": column,
+                "present": isinstance(cell, Cell),
+                "value": cell.value if isinstance(cell, Cell) else None,
+                "style_id": cell.style_id if isinstance(cell, Cell) else 0,
+                "has_style": bool(cell.has_style) if isinstance(cell, Cell) else False,
+            }
+        )
+    rows: list[dict[str, Any]] = []
+    for row in tail.empty_rows:
+        dimension = worksheet.row_dimensions.get(row)
+        rows.append(
+            {
+                "row": row,
+                "present": dimension is not None,
+                "height": dimension.height if dimension is not None else None,
+                "hidden": bool(dimension.hidden) if dimension is not None else False,
+                "style_id": dimension.style_id if dimension is not None else 0,
+                "outline_level": dimension.outlineLevel if dimension is not None else 0,
+                "collapsed": bool(dimension.collapsed) if dimension is not None else False,
+            }
+        )
+    return sha256_bytes(stable_json_bytes({"cells": cells, "rows": rows}))
+
+
+def whitespace_tail_layout_fingerprint(worksheet: Worksheet, tail: WhitespaceTail) -> str:
+    """Hash exact whitespace cells and their preserved row-dimension state."""
+
+    cells: list[dict[str, Any]] = []
+    rows: dict[int, dict[str, Any]] = {}
+    for coordinate in tail.cell_coordinates:
+        target = CellRange(coordinate)
+        row = target.min_row
+        column = target.min_col
+        cell = worksheet._cells.get((row, column))
+        cells.append(
+            {
+                "row": row,
+                "column": column,
+                "present": isinstance(cell, Cell),
+                "value": cell.value if isinstance(cell, Cell) else None,
+                "data_type": cell.data_type if isinstance(cell, Cell) else None,
+                "style_id": cell.style_id if isinstance(cell, Cell) else 0,
+                "number_format": cell.number_format if isinstance(cell, Cell) else None,
+                "quote_prefix": bool(cell.quotePrefix) if isinstance(cell, Cell) else False,
+            }
+        )
+        dimension = worksheet.row_dimensions.get(row)
+        rows[row] = {
+            "row": row,
+            "present": dimension is not None,
+            "height": dimension.height if dimension is not None else None,
+            "hidden": bool(dimension.hidden) if dimension is not None else False,
+            "style_id": dimension.style_id if dimension is not None else 0,
+            "outline_level": dimension.outlineLevel if dimension is not None else 0,
+            "collapsed": bool(dimension.collapsed) if dimension is not None else False,
+        }
+    return sha256_bytes(
+        stable_json_bytes(
+            {
+                "cells": cells,
+                "rows": [rows[row] for row in sorted(rows)],
+                "observed_dimension": tail.observed_dimension,
+                "result_dimension": tail.result_dimension,
+                "preserve_style_ids": [
+                    list(item)
+                    for item in sorted(
+                        tail.preserve_style_ids,
+                        key=lambda item: coordinate_to_tuple(item[0]),
+                    )
+                ],
+            }
+        )
+    )
+
+
+def range_intersects(left: str, right: str) -> bool:
+    """Return whether two A1 ranges overlap."""
+
+    return not CellRange(left).isdisjoint(CellRange(right))
+
+
+__all__ = [
+    "FormattingTail",
+    "TextMeasurement",
+    "WhitespaceTail",
+    "border_is_missing_only",
+    "border_signature",
+    "column_layout_fingerprint",
+    "column_width",
+    "estimated_text_width",
+    "explicit_row_height",
+    "find_formatting_tail",
+    "find_whitespace_tail",
+    "has_visible_border",
+    "measure_text_cell",
+    "non_border_style_key",
+    "range_intersects",
+    "row_height",
+    "row_layout_fingerprint",
+    "sheet_view_fingerprint",
+    "tail_layout_fingerprint",
+    "text_display_units",
+    "visual_border_signature",
+    "whitespace_tail_layout_fingerprint",
+]

--- a/src/workbooklens/models/__init__.py
+++ b/src/workbooklens/models/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator, model_validator
 
 
 class StrictModel(BaseModel):
@@ -79,6 +79,12 @@ class SheetSnapshot(StrictModel):
     state: Literal["visible", "hidden", "veryHidden"]
     max_row: int
     max_column: int
+    declared_dimension: str | None = None
+    content_dimension: str | None = None
+    row_heights: dict[str, float] = Field(default_factory=dict)
+    column_widths: dict[str, float] = Field(default_factory=dict)
+    view_top_left_cell: str | None = None
+    view_zoom_scale: int | None = None
     cells: dict[str, CellSnapshot] = Field(default_factory=dict)
     merged_ranges: list[str] = Field(default_factory=list)
     hidden_rows: list[int] = Field(default_factory=list)
@@ -115,6 +121,37 @@ class PatchKind(StrEnum):
     COPY_STYLE = "copy_style"
     EXTEND_SUM = "extend_sum"
     CREATE_FORMULA = "create_formula"
+    SET_COLUMN_WIDTH = "set_column_width"
+    SET_ROW_HEIGHT = "set_row_height"
+    SET_WRAP_TEXT = "set_wrap_text"
+    SET_SHRINK_TO_FIT = "set_shrink_to_fit"
+    SET_TEXT = "set_text"
+    SET_SHEET_VIEW = "set_sheet_view"
+    COPY_BORDER = "copy_border"
+    CLEAR_FORMATTING_TAIL = "clear_formatting_tail"
+    REMOVE_WHITESPACE_TAIL_CELLS = "remove_whitespace_tail_cells"
+
+
+class PatchRisk(StrEnum):
+    """Review boundary for repair selection, independent of rule confidence."""
+
+    SAFE = "safe"
+    LAYOUT_REVIEW = "layout_review"
+
+
+LAYOUT_REVIEW_PATCH_KINDS = frozenset(
+    {
+        PatchKind.SET_COLUMN_WIDTH,
+        PatchKind.SET_ROW_HEIGHT,
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_SHRINK_TO_FIT,
+        PatchKind.SET_TEXT,
+        PatchKind.SET_SHEET_VIEW,
+        PatchKind.COPY_BORDER,
+        PatchKind.CLEAR_FORMATTING_TAIL,
+        PatchKind.REMOVE_WHITESPACE_TAIL_CELLS,
+    }
+)
 
 
 class PatchPrecondition(StrictModel):
@@ -124,6 +161,7 @@ class PatchPrecondition(StrictModel):
     expected_value: Any = None
     expected_formula: str | None = None
     expected_style_id: int | None = None
+    layout_fingerprint: str | None = None
 
 
 class PatchOperation(StrictModel):
@@ -138,8 +176,49 @@ class PatchOperation(StrictModel):
     source_cell: str | None = None
     confidence: Confidence
     safe: bool
+    risk: PatchRisk = PatchRisk.SAFE
     description: str
     precondition: PatchPrecondition
+    atomic_group: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def infer_layout_review_risk(cls, value: Any) -> Any:
+        """Keep legacy constructors working while never inferring layout safety from confidence."""
+
+        if not isinstance(value, dict) or "risk" in value:
+            return value
+        kind = value.get("kind")
+        try:
+            if isinstance(kind, PatchKind):
+                patch_kind = kind
+            elif isinstance(kind, str):
+                patch_kind = PatchKind(kind)
+            else:
+                return value
+        except ValueError:
+            return value
+        if patch_kind not in LAYOUT_REVIEW_PATCH_KINDS:
+            return value
+        normalized = dict(value)
+        normalized["risk"] = PatchRisk.LAYOUT_REVIEW
+        return normalized
+
+    @model_validator(mode="after")
+    def require_layout_review(self) -> PatchOperation:
+        """Prevent callers from marking layout-changing operations safe-only eligible."""
+
+        if self.kind in LAYOUT_REVIEW_PATCH_KINDS and self.risk != PatchRisk.LAYOUT_REVIEW:
+            raise ValueError(f"{self.kind.value} patches require risk='layout_review'")
+        if self.risk == PatchRisk.LAYOUT_REVIEW and self.safe:
+            raise ValueError("layout_review patches require safe=false")
+        return self
+
+    @property
+    def safe_only_eligible(self) -> bool:
+        """Return whether ``--safe-only`` may select this operation."""
+
+        return self.safe and self.risk == PatchRisk.SAFE and float(self.confidence) >= 0.95
 
 
 class Finding(StrictModel):
@@ -165,7 +244,7 @@ class Finding(StrictModel):
 class PatchPlan(StrictModel):
     """A source-bound collection of proposed patches for explicit review."""
 
-    schema_version: Literal[1] = 1
+    schema_version: Literal[2] = 2
     tool_version: str
     source_name: str
     source_sha256: str
@@ -277,6 +356,7 @@ __all__ = [
     "PatchPlan",
     "PatchPrecondition",
     "PatchResult",
+    "PatchRisk",
     "Region",
     "Severity",
     "SheetSnapshot",

--- a/src/workbooklens/ooxml/safety.py
+++ b/src/workbooklens/ooxml/safety.py
@@ -188,29 +188,44 @@ def _inspect_content_types(
     if root.tag != f"{{{CONTENT_TYPES_NS}}}Types":
         raise UnsafeWorkbookError("Unexpected root element in '[Content_Types].xml'")
 
-    workbook_content_types: set[str] = set()
+    overrides: dict[str, set[str]] = {}
+    defaults: dict[str, set[str]] = {}
     has_macro_content_type = False
     for declaration in root:
-        content_type = declaration.get("ContentType", "")
-        lowered = content_type.lower()
-        if "vbaproject" in lowered or "macroenabled" in lowered:
+        content_type = declaration.get("ContentType", "").strip().lower()
+        if "vbaproject" in content_type or "macroenabled" in content_type:
             has_macro_content_type = True
-        if declaration.tag != f"{{{CONTENT_TYPES_NS}}}Override":
-            continue
-        declared_part = declaration.get("PartName", "").lstrip("/")
-        if declared_part == "xl/workbook.xml" and content_type:
-            workbook_content_types.add(content_type)
+        if declaration.tag == f"{{{CONTENT_TYPES_NS}}}Override":
+            declared_part = declaration.get("PartName", "").strip().lstrip("/")
+            if declared_part:
+                overrides.setdefault(declared_part, set()).add(content_type)
+        elif declaration.tag == f"{{{CONTENT_TYPES_NS}}}Default":
+            extension = declaration.get("Extension", "").strip().lstrip(".").lower()
+            if extension:
+                defaults.setdefault(extension, set()).add(content_type)
 
-    if len(workbook_content_types) > 1:
-        raise UnsafeWorkbookError("Workbook has conflicting content-type declarations")
+    for declared_part, content_types in overrides.items():
+        if len(content_types) > 1:
+            raise UnsafeWorkbookError(
+                f"Part {declared_part!r} has conflicting Override content-type declarations"
+            )
+    for extension, content_types in defaults.items():
+        if len(content_types) > 1:
+            raise UnsafeWorkbookError(
+                f"Extension {extension!r} has conflicting Default content-type declarations"
+            )
+
+    workbook_content_types = overrides.get("xl/workbook.xml")
+    if workbook_content_types is None:
+        workbook_content_types = defaults.get("xml")
     if not workbook_content_types:
         return None, has_macro_content_type
 
     workbook_content_type = next(iter(workbook_content_types))
-    if workbook_content_type == XLSX_WORKBOOK_CONTENT_TYPE:
+    if workbook_content_type == XLSX_WORKBOOK_CONTENT_TYPE.lower():
         return "xlsx", has_macro_content_type
-    if workbook_content_type == XLSM_WORKBOOK_CONTENT_TYPE or "macroenabled" in (
-        workbook_content_type.lower()
+    if workbook_content_type == XLSM_WORKBOOK_CONTENT_TYPE.lower() or "macroenabled" in (
+        workbook_content_type
     ):
         return "xlsm", True
     return None, has_macro_content_type
@@ -235,7 +250,7 @@ def inspect_package(path: Path, limits: PackageLimits | None = None) -> PackageI
         raise UsageError(f"Workbook does not exist or is not a file: {path}")
     suffix = resolved.suffix.lower()
     if suffix not in {".xlsx", ".xlsm"}:
-        raise UsageError("WorkbookLens 2.1 accepts only .xlsx and read-only .xlsm inputs")
+        raise UsageError("WorkbookLens 2.2 accepts only .xlsx and read-only .xlsm inputs")
     file_size = resolved.stat().st_size
     if file_size > active_limits.max_file_bytes:
         raise UnsafeWorkbookError(

--- a/src/workbooklens/repair/engine.py
+++ b/src/workbooklens/repair/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
@@ -9,7 +10,7 @@ from workbooklens.exceptions import PatchValidationError
 from workbooklens.models import PatchPlan, PatchResult, Severity
 from workbooklens.ooxml.safety import PackageLimits
 from workbooklens.repair.ooxml_patch import patch_ooxml_package
-from workbooklens.repair.planning import build_patch_plan
+from workbooklens.repair.planning import build_patch_plan, resolve_patch_selection
 from workbooklens.scanner import scan_workbook
 
 
@@ -18,21 +19,29 @@ def apply_patch_plan(
     plan: PatchPlan,
     output: Path,
     *,
-    selected_ids: set[str] | None = None,
+    selected_ids: Collection[str] | None = None,
     safe_only: bool = False,
+    accept_layout_risk: bool = False,
     config: dict[str, Any] | None = None,
     limits: PackageLimits | None = None,
 ) -> PatchResult:
     """Apply, reopen, rescan, compare findings, and delete invalid output."""
 
+    resolved_ids = resolve_patch_selection(
+        plan,
+        selected_ids,
+        safe_only,
+        accept_layout_risk=accept_layout_risk,
+    )
     before_scan = scan_workbook(source, config=config, limits=limits)
     canonical_plan = build_patch_plan(before_scan)
     low_level, selected = patch_ooxml_package(
         source,
         plan,
         output,
-        selected_ids=selected_ids,
-        safe_only=safe_only,
+        selected_ids=resolved_ids,
+        safe_only=False,
+        accept_layout_risk=accept_layout_risk,
         limits=limits,
         canonical_plan=canonical_plan,
     )
@@ -40,6 +49,25 @@ def apply_patch_plan(
         after_scan = scan_workbook(output, config=config, limits=limits)
         before_ids = {finding.id for finding in before_scan.findings}
         after_ids = {finding.id for finding in after_scan.findings}
+        selected_patch_ids = {patch.id for patch in selected}
+        targeted_keys = {
+            (finding.rule_id, finding.sheet, finding.location)
+            for finding in before_scan.findings
+            if finding.patch_ids and set(finding.patch_ids).issubset(selected_patch_ids)
+        }
+        unresolved_targets = [
+            finding
+            for finding in after_scan.findings
+            if (finding.rule_id, finding.sheet, finding.location) in targeted_keys
+        ]
+        if unresolved_targets:
+            targets = ", ".join(
+                sorted(
+                    f"{finding.rule_id}:{finding.sheet}!{finding.location}"
+                    for finding in unresolved_targets
+                )
+            )
+            raise PatchValidationError(f"Repair did not resolve targeted findings: {targets}")
         new_findings = [finding for finding in after_scan.findings if finding.id not in before_ids]
         dangerous_new = [
             finding

--- a/src/workbooklens/repair/layout_ooxml.py
+++ b/src/workbooklens/repair/layout_ooxml.py
@@ -1,0 +1,1568 @@
+"""Fail-closed OOXML helpers for presentation-only workbook repairs."""
+
+from __future__ import annotations
+
+import copy
+import math
+import posixpath
+import re
+import zipfile
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any, cast
+
+from lxml import etree
+from openpyxl.formula import Tokenizer
+from openpyxl.formula.tokenizer import TokenizerError
+from openpyxl.utils.cell import (
+    column_index_from_string,
+    coordinate_to_tuple,
+    get_column_letter,
+    range_boundaries,
+)
+from openpyxl.worksheet.cell_range import CellRange
+from openpyxl.worksheet.worksheet import Worksheet
+
+from workbooklens.exceptions import PatchValidationError, StalePlanError
+from workbooklens.layout import (
+    FormattingTail,
+    WhitespaceTail,
+    column_layout_fingerprint,
+    row_layout_fingerprint,
+    sheet_view_fingerprint,
+    tail_layout_fingerprint,
+    whitespace_tail_layout_fingerprint,
+)
+from workbooklens.models import PatchKind, PatchOperation
+
+XML_SPACE = "{http://www.w3.org/XML/1998/namespace}space"
+MAX_EXCEL_COLUMN = 16_384
+MAX_EXCEL_ROW = 1_048_576
+MAX_TAIL_CELLS = 100_000
+CELL_REFERENCE_RE = re.compile(r"^[A-Z]{1,3}[1-9][0-9]{0,6}$")
+LAYOUT_KINDS = frozenset(
+    {
+        PatchKind.SET_COLUMN_WIDTH,
+        PatchKind.SET_ROW_HEIGHT,
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_SHRINK_TO_FIT,
+        PatchKind.SET_TEXT,
+        PatchKind.SET_SHEET_VIEW,
+        PatchKind.COPY_BORDER,
+        PatchKind.CLEAR_FORMATTING_TAIL,
+        PatchKind.REMOVE_WHITESPACE_TAIL_CELLS,
+    }
+)
+STYLE_LAYOUT_KINDS = frozenset(
+    {
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_SHRINK_TO_FIT,
+        PatchKind.SET_TEXT,
+        PatchKind.COPY_BORDER,
+    }
+)
+ALLOWED_BORDER_EDGES = frozenset({"left", "right", "top", "bottom"})
+
+
+def _qname(namespace: str, local_name: str) -> str:
+    return f"{{{namespace}}}{local_name}"
+
+
+def _namespace(element: etree._Element) -> str:
+    namespace = etree.QName(element).namespace
+    if namespace is None:
+        raise PatchValidationError("OOXML element is missing a namespace")
+    return namespace
+
+
+def _direct_child(root: etree._Element, local_name: str) -> etree._Element | None:
+    return next(
+        (child for child in root if etree.QName(child).localname == local_name),
+        None,
+    )
+
+
+def _direct_children(root: etree._Element, local_name: str) -> list[etree._Element]:
+    return [child for child in root if etree.QName(child).localname == local_name]
+
+
+def _parse_positive_int(value: str | None, label: str, *, maximum: int) -> int:
+    try:
+        parsed = int(cast(str, value))
+    except (TypeError, ValueError) as exc:
+        raise PatchValidationError(f"{label} is not a valid integer") from exc
+    if not 1 <= parsed <= maximum:
+        raise PatchValidationError(f"{label} is outside Excel bounds")
+    return parsed
+
+
+def _number_text(value: float) -> str:
+    return format(value, ".15g")
+
+
+def _as_finite_number(value: Any, label: str, *, minimum: float, maximum: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PatchValidationError(f"{label} must be numeric")
+    parsed = float(value)
+    if not math.isfinite(parsed) or not minimum <= parsed <= maximum:
+        raise PatchValidationError(f"{label} is outside the supported range")
+    return parsed
+
+
+def _validate_coordinate(value: Any, label: str = "cell coordinate") -> str:
+    if not isinstance(value, str):
+        raise PatchValidationError(f"{label} must be a string")
+    normalized = value.upper()
+    if not CELL_REFERENCE_RE.fullmatch(normalized):
+        raise PatchValidationError(f"Invalid {label}: {value!r}")
+    row, column = coordinate_to_tuple(normalized)
+    if row > MAX_EXCEL_ROW or column > MAX_EXCEL_COLUMN:
+        raise PatchValidationError(f"{label} is outside Excel bounds: {value!r}")
+    return normalized
+
+
+def _cell_element(root: etree._Element, coordinate: str) -> etree._Element | None:
+    return next(
+        (
+            element
+            for element in root.iter()
+            if etree.QName(element).localname == "c" and element.get("r") == coordinate
+        ),
+        None,
+    )
+
+
+def _row_element(root: etree._Element, row_number: int) -> etree._Element | None:
+    sheet_data = _direct_child(root, "sheetData")
+    if sheet_data is None:
+        raise PatchValidationError("Worksheet has no sheetData element")
+    return next(
+        (
+            row
+            for row in sheet_data
+            if etree.QName(row).localname == "row"
+            and _parse_positive_int(row.get("r"), "row r", maximum=MAX_EXCEL_ROW) == row_number
+        ),
+        None,
+    )
+
+
+def _cell_element_or_create(root: etree._Element, coordinate: str) -> etree._Element:
+    existing = _cell_element(root, coordinate)
+    if existing is not None:
+        return existing
+    row_number, column_number = coordinate_to_tuple(coordinate)
+    namespace = _namespace(root)
+    sheet_data = _direct_child(root, "sheetData")
+    if sheet_data is None:
+        raise PatchValidationError("Worksheet has no sheetData element")
+    row = _row_element(root, row_number)
+    if row is None:
+        row = etree.Element(_qname(namespace, "row"), r=str(row_number))
+        insertion_index = len(sheet_data)
+        for index, candidate in enumerate(sheet_data):
+            if etree.QName(candidate).localname != "row":
+                continue
+            candidate_row = _parse_positive_int(
+                candidate.get("r"),
+                "row r",
+                maximum=MAX_EXCEL_ROW,
+            )
+            if candidate_row > row_number:
+                insertion_index = index
+                break
+        sheet_data.insert(insertion_index, row)
+    cell = etree.Element(_qname(namespace, "c"), r=coordinate)
+    insertion_index = len(row)
+    for index, candidate in enumerate(row):
+        if etree.QName(candidate).localname != "c":
+            continue
+        candidate_coordinate = _validate_coordinate(
+            candidate.get("r"),
+            "worksheet cell coordinate",
+        )
+        _, candidate_column = coordinate_to_tuple(candidate_coordinate)
+        if candidate_column > column_number:
+            insertion_index = index
+            break
+    row.insert(insertion_index, cell)
+    return cell
+
+
+def _style_index(cell: etree._Element) -> int:
+    value = cell.get("s")
+    if value is None:
+        return 0
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise PatchValidationError("Cell style index is invalid") from exc
+    if not 0 <= parsed <= 2_147_483_647:
+        raise PatchValidationError("Cell style index is outside supported bounds")
+    return parsed
+
+
+def _canonical(element: etree._Element) -> bytes:
+    return etree.tostring(element, method="c14n", with_comments=True)
+
+
+def _validate_count(collection: etree._Element, label: str) -> None:
+    declared = collection.get("count")
+    if declared is None:
+        return
+    try:
+        parsed = int(declared)
+    except ValueError as exc:
+        raise PatchValidationError(f"{label} has an invalid count") from exc
+    if parsed != len(collection):
+        raise PatchValidationError(f"{label} count does not match its children")
+
+
+def _find_equivalent(collection: etree._Element, candidate: etree._Element) -> int | None:
+    signature = _canonical(candidate)
+    for index, existing in enumerate(collection):
+        if _canonical(existing) == signature:
+            return index
+    return None
+
+
+def _append_unique(collection: etree._Element, candidate: etree._Element) -> tuple[int, bool]:
+    existing = _find_equivalent(collection, candidate)
+    if existing is not None:
+        return existing, False
+    collection.append(candidate)
+    collection.set("count", str(len(collection)))
+    return len(collection) - 1, True
+
+
+def _insert_xf_child(xf: etree._Element, child: etree._Element) -> None:
+    order = {"alignment": 0, "protection": 1, "extLst": 2}
+    target_order = order.get(etree.QName(child).localname, 99)
+    insertion_index = len(xf)
+    for index, existing in enumerate(xf):
+        if order.get(etree.QName(existing).localname, 99) > target_order:
+            insertion_index = index
+            break
+    xf.insert(insertion_index, child)
+
+
+def _replace_border_edge(
+    border: etree._Element, edge_name: str, replacement: etree._Element
+) -> None:
+    order = {
+        "start": 0,
+        "end": 1,
+        "left": 2,
+        "right": 3,
+        "top": 4,
+        "bottom": 5,
+        "diagonal": 6,
+        "vertical": 7,
+        "horizontal": 8,
+        "extLst": 9,
+    }
+    existing = next(
+        (child for child in border if etree.QName(child).localname == edge_name),
+        None,
+    )
+    if existing is not None:
+        border.replace(existing, replacement)
+        return
+    target_order = order[edge_name]
+    insertion_index = len(border)
+    for index, child in enumerate(border):
+        if order.get(etree.QName(child).localname, 99) > target_order:
+            insertion_index = index
+            break
+    border.insert(insertion_index, replacement)
+
+
+@dataclass(slots=True)
+class StylesEditor:
+    """Mutable style-table view that preserves every unmodified style field."""
+
+    root: etree._Element
+    cell_xfs: etree._Element
+    borders: etree._Element
+    dirty: bool = False
+
+    @classmethod
+    def from_root(cls, root: etree._Element) -> StylesEditor:
+        cell_xfs = _direct_child(root, "cellXfs")
+        borders = _direct_child(root, "borders")
+        if cell_xfs is None or borders is None:
+            raise PatchValidationError("Workbook styles.xml lacks cellXfs or borders")
+        _validate_count(cell_xfs, "cellXfs")
+        _validate_count(borders, "borders")
+        if not len(cell_xfs) or not len(borders):
+            raise PatchValidationError("Workbook styles.xml has an empty style collection")
+        return cls(root=root, cell_xfs=cell_xfs, borders=borders)
+
+    def _xf(self, cell: etree._Element) -> etree._Element:
+        index = _style_index(cell)
+        if index >= len(self.cell_xfs):
+            raise PatchValidationError(f"Cell references missing style index {index}")
+        return self.cell_xfs[index]
+
+    def _assign_xf(self, cell: etree._Element, candidate: etree._Element) -> None:
+        index, appended = _append_unique(self.cell_xfs, candidate)
+        cell.set("s", str(index))
+        self.dirty = self.dirty or appended
+
+    def set_alignment_flag(self, cell: etree._Element, attribute: str, enabled: bool) -> None:
+        candidate = copy.deepcopy(self._xf(cell))
+        alignment = _direct_child(candidate, "alignment")
+        if alignment is None:
+            alignment = etree.Element(_qname(_namespace(candidate), "alignment"))
+            _insert_xf_child(candidate, alignment)
+        if enabled:
+            alignment.set(attribute, "1")
+        else:
+            if attribute in alignment.attrib:
+                del alignment.attrib[attribute]
+        candidate.set("applyAlignment", "1")
+        self._assign_xf(cell, candidate)
+
+    def set_text_number_format(self, cell: etree._Element) -> None:
+        candidate = copy.deepcopy(self._xf(cell))
+        candidate.set("numFmtId", "49")
+        candidate.set("applyNumberFormat", "1")
+        self._assign_xf(cell, candidate)
+
+    def copy_border_edge(
+        self,
+        target: etree._Element,
+        source: etree._Element,
+        *,
+        target_edge: str,
+        source_edge: str,
+    ) -> None:
+        target_xf = self._xf(target)
+        source_xf = self._xf(source)
+        try:
+            target_border_id = int(target_xf.get("borderId", "0"))
+            source_border_id = int(source_xf.get("borderId", "0"))
+        except ValueError as exc:
+            raise PatchValidationError("Cell style has an invalid borderId") from exc
+        if not 0 <= target_border_id < len(self.borders):
+            raise PatchValidationError("Target style references a missing border")
+        if not 0 <= source_border_id < len(self.borders):
+            raise PatchValidationError("Source style references a missing border")
+        source_border = self.borders[source_border_id]
+        source_side = next(
+            (child for child in source_border if etree.QName(child).localname == source_edge),
+            None,
+        )
+        if source_side is None:
+            raise PatchValidationError(f"Source border has no {source_edge} edge")
+        source_style = (source_side.get("style") or "").strip()
+        if not source_style or source_style.casefold() == "none":
+            raise PatchValidationError(f"Source border {source_edge} edge is not visibly styled")
+        candidate_border = copy.deepcopy(self.borders[target_border_id])
+        replacement = copy.deepcopy(source_side)
+        replacement.tag = _qname(_namespace(candidate_border), target_edge)
+        _replace_border_edge(candidate_border, target_edge, replacement)
+        border_id, border_appended = _append_unique(self.borders, candidate_border)
+        self.dirty = self.dirty or border_appended
+        candidate_xf = copy.deepcopy(target_xf)
+        candidate_xf.set("borderId", str(border_id))
+        candidate_xf.set("applyBorder", "1")
+        self._assign_xf(target, candidate_xf)
+
+
+def is_layout_kind(kind: PatchKind) -> bool:
+    return kind in LAYOUT_KINDS
+
+
+def needs_styles(kind: PatchKind) -> bool:
+    return kind in STYLE_LAYOUT_KINDS
+
+
+def _column_payload(patch: PatchOperation) -> tuple[int, float]:
+    if isinstance(patch.after, dict):
+        if set(patch.after) != {"column", "width"}:
+            raise PatchValidationError(f"Patch {patch.id} has an invalid column-width payload")
+        column_text = patch.after["column"]
+        width_value = patch.after["width"]
+    else:
+        _, target_column = coordinate_to_tuple(_validate_coordinate(patch.cell))
+        column_text = get_column_letter(target_column)
+        width_value = patch.after
+    if not isinstance(column_text, str):
+        raise PatchValidationError("Column-width payload column must be a letter")
+    try:
+        column = column_index_from_string(column_text.upper())
+    except ValueError as exc:
+        raise PatchValidationError(f"Invalid column letter: {column_text!r}") from exc
+    if not 1 <= column <= MAX_EXCEL_COLUMN:
+        raise PatchValidationError("Column-width target is outside Excel bounds")
+    width = _as_finite_number(width_value, "column width", minimum=0.1, maximum=255.0)
+    _, anchor_column = coordinate_to_tuple(_validate_coordinate(patch.cell))
+    if anchor_column != column:
+        raise PatchValidationError("Column-width patch anchor does not match its target column")
+    return column, width
+
+
+def _row_payload(patch: PatchOperation) -> tuple[int, float]:
+    if isinstance(patch.after, dict):
+        if set(patch.after) != {"row", "height"}:
+            raise PatchValidationError(f"Patch {patch.id} has an invalid row-height payload")
+        row_value = patch.after["row"]
+        height_value = patch.after["height"]
+    else:
+        row_value, _ = coordinate_to_tuple(_validate_coordinate(patch.cell))
+        height_value = patch.after
+    if isinstance(row_value, bool) or not isinstance(row_value, int):
+        raise PatchValidationError("Row-height payload row must be an integer")
+    if not 1 <= row_value <= MAX_EXCEL_ROW:
+        raise PatchValidationError("Row-height target is outside Excel bounds")
+    height = _as_finite_number(height_value, "row height", minimum=0.1, maximum=409.5)
+    anchor_row, _ = coordinate_to_tuple(_validate_coordinate(patch.cell))
+    if anchor_row != row_value:
+        raise PatchValidationError("Row-height patch anchor does not match its target row")
+    return row_value, height
+
+
+def _boolean_payload(patch: PatchOperation, key: str) -> bool:
+    if isinstance(patch.after, dict):
+        if set(patch.after) != {key}:
+            raise PatchValidationError(f"Patch {patch.id} has an invalid {key} payload")
+        value = patch.after[key]
+    else:
+        value = patch.after
+    if not isinstance(value, bool):
+        raise PatchValidationError(f"Patch {patch.id} {key} value must be boolean")
+    return value
+
+
+def _view_payload(patch: PatchOperation) -> tuple[str | None, int | None]:
+    if isinstance(patch.after, str):
+        return _validate_coordinate(patch.after, "top-left cell"), None
+    if not isinstance(patch.after, dict):
+        raise PatchValidationError(f"Patch {patch.id} has an invalid sheet-view payload")
+    allowed = {"top_left_cell", "zoom_scale"}
+    if not patch.after or not set(patch.after) <= allowed:
+        raise PatchValidationError(f"Patch {patch.id} has an invalid sheet-view payload")
+    top_left = (
+        _validate_coordinate(patch.after["top_left_cell"], "top-left cell")
+        if "top_left_cell" in patch.after
+        else None
+    )
+    if "zoom_scale" not in patch.after:
+        return top_left, None
+    zoom_value = patch.after["zoom_scale"]
+    if isinstance(zoom_value, bool) or not isinstance(zoom_value, int):
+        raise PatchValidationError("Sheet-view zoom_scale must be an integer")
+    if not 10 <= zoom_value <= 400:
+        raise PatchValidationError("Sheet-view zoom_scale is outside Excel bounds")
+    return top_left, zoom_value
+
+
+def _border_payload(patch: PatchOperation) -> tuple[str, str]:
+    if isinstance(patch.after, str):
+        target_edge = source_edge = patch.after
+    elif isinstance(patch.after, dict):
+        if set(patch.after) != {"target_edge", "source_edge"}:
+            raise PatchValidationError(f"Patch {patch.id} has an invalid border payload")
+        target_edge = patch.after["target_edge"]
+        source_edge = patch.after["source_edge"]
+    else:
+        raise PatchValidationError(f"Patch {patch.id} has an invalid border payload")
+    if target_edge not in ALLOWED_BORDER_EDGES or source_edge not in ALLOWED_BORDER_EDGES:
+        raise PatchValidationError("Border patch uses an unsupported edge")
+    return target_edge, source_edge
+
+
+def _tail_payload(patch: PatchOperation) -> tuple[list[str], list[int], str, str]:
+    if not isinstance(patch.after, dict):
+        raise PatchValidationError(f"Patch {patch.id} has an invalid formatting-tail payload")
+    required = {"cells", "empty_rows", "expected_dimension", "result_dimension"}
+    if set(patch.after) != required:
+        raise PatchValidationError(f"Patch {patch.id} has an invalid formatting-tail payload")
+    raw_cells = patch.after["cells"]
+    raw_rows = patch.after["empty_rows"]
+    if not isinstance(raw_cells, list) or not isinstance(raw_rows, list):
+        raise PatchValidationError("Formatting-tail cells and empty_rows must be lists")
+    if len(raw_cells) > MAX_TAIL_CELLS:
+        raise PatchValidationError("Formatting-tail cell authorization is too large")
+    cells = [_validate_coordinate(value, "formatting-tail cell") for value in raw_cells]
+    if not cells or len(set(cells)) != len(cells):
+        raise PatchValidationError("Formatting-tail cells must be a non-empty unique list")
+    rows: list[int] = []
+    for value in raw_rows:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise PatchValidationError("Formatting-tail row must be an integer")
+        if not 1 <= value <= MAX_EXCEL_ROW:
+            raise PatchValidationError("Formatting-tail row is outside Excel bounds")
+        rows.append(value)
+    if len(set(rows)) != len(rows):
+        raise PatchValidationError("Formatting-tail rows must be unique")
+    expected = patch.after["expected_dimension"]
+    result = patch.after["result_dimension"]
+    for label, value in (("expected_dimension", expected), ("result_dimension", result)):
+        if not isinstance(value, str):
+            raise PatchValidationError(f"Formatting-tail {label} must be a string")
+        try:
+            CellRange(value)
+        except ValueError as exc:
+            raise PatchValidationError(f"Formatting-tail {label} is invalid") from exc
+    return cells, rows, cast(str, expected), cast(str, result)
+
+
+def _whitespace_tail_payload(
+    patch: PatchOperation,
+) -> tuple[list[str], dict[str, int], str, str]:
+    if not isinstance(patch.after, dict):
+        raise PatchValidationError(f"Patch {patch.id} has an invalid whitespace-tail payload")
+    required = {
+        "cells",
+        "expected_dimension",
+        "preserve_style_ids",
+        "result_dimension",
+        "preserve_row_dimensions",
+    }
+    if set(patch.after) != required or patch.after["preserve_row_dimensions"] is not True:
+        raise PatchValidationError(f"Patch {patch.id} has an invalid whitespace-tail payload")
+    raw_cells = patch.after["cells"]
+    if not isinstance(raw_cells, list) or not 1 <= len(raw_cells) <= 4_096:
+        raise PatchValidationError("Whitespace-tail cells must be a bounded non-empty list")
+    cells = [_validate_coordinate(value, "whitespace-tail cell") for value in raw_cells]
+    if len(set(cells)) != len(cells):
+        raise PatchValidationError("Whitespace-tail cells must be unique")
+    raw_preserve_styles = patch.after["preserve_style_ids"]
+    if not isinstance(raw_preserve_styles, dict):
+        raise PatchValidationError("Whitespace-tail preserve_style_ids must be an object")
+    preserve_style_ids: dict[str, int] = {}
+    for raw_coordinate, raw_style_id in raw_preserve_styles.items():
+        coordinate = _validate_coordinate(raw_coordinate, "preserved-style whitespace cell")
+        if (
+            coordinate not in cells
+            or isinstance(raw_style_id, bool)
+            or not isinstance(raw_style_id, int)
+            or raw_style_id <= 0
+        ):
+            raise PatchValidationError(
+                "Whitespace-tail preserved styles must map authorized cells to positive style IDs"
+            )
+        preserve_style_ids[coordinate] = raw_style_id
+    expected = patch.after["expected_dimension"]
+    result = patch.after["result_dimension"]
+    for label, value in (("expected_dimension", expected), ("result_dimension", result)):
+        if not isinstance(value, str):
+            raise PatchValidationError(f"Whitespace-tail {label} must be a string")
+        try:
+            CellRange(value)
+        except ValueError as exc:
+            raise PatchValidationError(f"Whitespace-tail {label} is invalid") from exc
+    return cells, preserve_style_ids, cast(str, expected), cast(str, result)
+
+
+def patch_target_key(patch: PatchOperation) -> tuple[str, str, str]:
+    """Return a conflict key that reflects the actual OOXML mutation domain."""
+
+    if patch.kind == PatchKind.SET_COLUMN_WIDTH:
+        column, _ = _column_payload(patch)
+        return patch.sheet, f"column:{column}", "column-width"
+    if patch.kind == PatchKind.SET_ROW_HEIGHT:
+        row, _ = _row_payload(patch)
+        return patch.sheet, f"row:{row}", "row-height"
+    if patch.kind == PatchKind.SET_SHEET_VIEW:
+        _view_payload(patch)
+        return patch.sheet, "sheet-view", "sheet-view"
+    if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL:
+        _tail_payload(patch)
+        return patch.sheet, "worksheet-dimension-cleanup", "worksheet-dimension-cleanup"
+    if patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS:
+        _whitespace_tail_payload(patch)
+        return patch.sheet, "worksheet-dimension-cleanup", "worksheet-dimension-cleanup"
+    if patch.kind == PatchKind.SET_WRAP_TEXT:
+        _boolean_payload(patch, "wrap_text")
+        return patch.sheet, patch.cell, "alignment-wrap"
+    if patch.kind == PatchKind.SET_SHRINK_TO_FIT:
+        _boolean_payload(patch, "shrink_to_fit")
+        return patch.sheet, patch.cell, "alignment-shrink"
+    if patch.kind == PatchKind.COPY_BORDER:
+        target_edge, _ = _border_payload(patch)
+        return patch.sheet, patch.cell, f"border-{target_edge}"
+    if patch.kind == PatchKind.COPY_STYLE:
+        return patch.sheet, patch.cell, "style-all"
+    return patch.sheet, patch.cell, "content"
+
+
+def tail_authorization(patch: PatchOperation) -> tuple[set[str], set[int]]:
+    cells, rows, _, _ = _tail_payload(patch)
+    return set(cells), set(rows)
+
+
+def whitespace_tail_authorization(patch: PatchOperation) -> set[str]:
+    cells, _, _, _ = _whitespace_tail_payload(patch)
+    return set(cells)
+
+
+def whitespace_tail_preserved_style_ids(patch: PatchOperation) -> dict[str, int]:
+    """Return cells whose style node must survive whitespace-value cleanup."""
+
+    _, preserve_style_ids, _, _ = _whitespace_tail_payload(patch)
+    return preserve_style_ids
+
+
+def verify_layout_precondition(worksheet: Worksheet, patch: PatchOperation) -> None:
+    """Validate the layout fingerprint with the same source state used by the rules."""
+
+    expected = patch.precondition.layout_fingerprint
+    actual: str | None
+    if patch.kind == PatchKind.SET_COLUMN_WIDTH:
+        column, _ = _column_payload(patch)
+        actual = column_layout_fingerprint(worksheet, column)
+    elif patch.kind == PatchKind.SET_ROW_HEIGHT:
+        row, _ = _row_payload(patch)
+        actual = row_layout_fingerprint(worksheet, row)
+    elif patch.kind == PatchKind.SET_SHEET_VIEW:
+        _view_payload(patch)
+        actual = sheet_view_fingerprint(worksheet)
+    elif patch.kind == PatchKind.CLEAR_FORMATTING_TAIL:
+        cells, rows, _, _ = _tail_payload(patch)
+        tail = FormattingTail(
+            cell_coordinates=tuple(cells),
+            cell_ranges=tuple(cells),
+            empty_rows=tuple(rows),
+            row_ranges=tuple(str(row) for row in rows),
+            styled_cell_count=len(cells),
+            content_min_row=0,
+            content_min_column=0,
+            content_max_row=0,
+            content_max_column=0,
+            observed_max_row=0,
+            observed_max_column=0,
+        )
+        actual = tail_layout_fingerprint(worksheet, tail)
+    elif patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS:
+        cells, preserve_style_ids, expected_dimension, result_dimension = _whitespace_tail_payload(
+            patch
+        )
+        ranges = tuple(cells)
+        rows = [coordinate_to_tuple(coordinate)[0] for coordinate in cells]
+        columns = [coordinate_to_tuple(coordinate)[1] for coordinate in cells]
+        whitespace_tail = WhitespaceTail(
+            cell_coordinates=tuple(cells),
+            cell_ranges=ranges,
+            row_ranges=(),
+            content_min_row=min(rows),
+            content_min_column=min(columns),
+            content_max_row=max(rows),
+            content_max_column=max(columns),
+            observed_dimension=expected_dimension,
+            result_dimension=result_dimension,
+            preserve_style_ids=tuple(
+                sorted(
+                    preserve_style_ids.items(),
+                    key=lambda item: coordinate_to_tuple(item[0]),
+                )
+            ),
+        )
+        actual = whitespace_tail_layout_fingerprint(worksheet, whitespace_tail)
+    else:
+        if expected is not None:
+            raise PatchValidationError(
+                f"Patch {patch.id} supplies an unsupported layout fingerprint"
+            )
+        return
+    if expected is None:
+        raise PatchValidationError(f"Patch {patch.id} is missing its layout fingerprint")
+    if actual != expected:
+        raise StalePlanError(f"Layout precondition failed for patch {patch.id}; plan is stale")
+
+
+def apply_column_width(root: etree._Element, patch: PatchOperation) -> None:
+    column, width = _column_payload(patch)
+    namespace = _namespace(root)
+    cols_elements = _direct_children(root, "cols")
+    if len(cols_elements) > 1:
+        raise PatchValidationError("Worksheet contains multiple cols collections")
+    if cols_elements:
+        cols = cols_elements[0]
+    else:
+        cols = etree.Element(_qname(namespace, "cols"))
+        sheet_data = _direct_child(root, "sheetData")
+        if sheet_data is None:
+            raise PatchValidationError("Worksheet has no sheetData element")
+        root.insert(root.index(sheet_data), cols)
+    definitions: list[tuple[int, int, etree._Element]] = []
+    for element in cols:
+        if etree.QName(element).localname != "col":
+            raise PatchValidationError("cols contains an unsupported child element")
+        minimum = _parse_positive_int(element.get("min"), "col min", maximum=MAX_EXCEL_COLUMN)
+        maximum = _parse_positive_int(element.get("max"), "col max", maximum=MAX_EXCEL_COLUMN)
+        if minimum > maximum:
+            raise PatchValidationError("Column definition has min greater than max")
+        definitions.append((minimum, maximum, element))
+    ordered = sorted(definitions, key=lambda item: (item[0], item[1]))
+    for previous, current in pairwise(ordered):
+        if current[0] <= previous[1]:
+            raise PatchValidationError("Worksheet contains overlapping column definitions")
+    covering = [item for item in definitions if item[0] <= column <= item[1]]
+    if len(covering) > 1:
+        raise PatchValidationError("Target column has overlapping definitions")
+    replacement_elements: list[etree._Element] = []
+    if covering:
+        minimum, maximum, original = covering[0]
+        if minimum < column:
+            left = copy.deepcopy(original)
+            left.set("min", str(minimum))
+            left.set("max", str(column - 1))
+            replacement_elements.append(left)
+        target = copy.deepcopy(original)
+        target.set("min", str(column))
+        target.set("max", str(column))
+        target.set("width", _number_text(width))
+        target.set("customWidth", "1")
+        replacement_elements.append(target)
+        if column < maximum:
+            right = copy.deepcopy(original)
+            right.set("min", str(column + 1))
+            right.set("max", str(maximum))
+            replacement_elements.append(right)
+        index = cols.index(original)
+        cols.remove(original)
+        for offset, element in enumerate(replacement_elements):
+            cols.insert(index + offset, element)
+    else:
+        target = etree.Element(
+            _qname(namespace, "col"),
+            min=str(column),
+            max=str(column),
+            width=_number_text(width),
+            customWidth="1",
+        )
+        insertion_index = len(cols)
+        for minimum, _, element in definitions:
+            if minimum > column:
+                insertion_index = cols.index(element)
+                break
+        cols.insert(insertion_index, target)
+
+
+def apply_row_height(root: etree._Element, patch: PatchOperation) -> None:
+    row_number, height = _row_payload(patch)
+    row = _row_element(root, row_number)
+    if row is None:
+        raise PatchValidationError("Row-height target row is absent from worksheet XML")
+    row.set("ht", _number_text(height))
+    row.set("customHeight", "1")
+
+
+def apply_alignment(
+    root: etree._Element, patch: PatchOperation, styles: StylesEditor, *, shrink: bool
+) -> None:
+    coordinate = _validate_coordinate(patch.cell)
+    cell = _cell_element(root, coordinate)
+    if cell is None:
+        raise PatchValidationError(f"Alignment target cell is absent: {coordinate}")
+    key = "shrink_to_fit" if shrink else "wrap_text"
+    value = _boolean_payload(patch, key)
+    styles.set_alignment_flag(cell, "shrinkToFit" if shrink else "wrapText", value)
+
+
+def apply_set_text(root: etree._Element, patch: PatchOperation, styles: StylesEditor) -> None:
+    coordinate = _validate_coordinate(patch.cell)
+    cell = _cell_element(root, coordinate)
+    if cell is None:
+        raise PatchValidationError(f"Text target cell is absent: {coordinate}")
+    if not isinstance(patch.after, str):
+        raise PatchValidationError(f"Patch {patch.id} text output must be a string")
+    child_names = [etree.QName(child).localname for child in cell]
+    if "f" in child_names:
+        raise PatchValidationError("SET_TEXT refuses to replace a formula")
+    unsupported_attributes = {str(name) for name in cell.attrib} - {"r", "s", "t"}
+    if unsupported_attributes:
+        raise PatchValidationError(
+            "SET_TEXT refuses cell metadata attributes: "
+            + ", ".join(sorted(unsupported_attributes))
+        )
+    unsupported_children = set(child_names) - {"v", "is", "extLst"}
+    if unsupported_children:
+        raise PatchValidationError(
+            "SET_TEXT refuses unsupported cell children: " + ", ".join(sorted(unsupported_children))
+        )
+    if child_names.count("v") > 1 or child_names.count("is") > 1:
+        raise PatchValidationError("SET_TEXT refuses duplicate value children")
+    if child_names.count("extLst") > 1:
+        raise PatchValidationError("SET_TEXT refuses duplicate extLst children")
+    for child in list(cell):
+        if etree.QName(child).localname in {"v", "is"}:
+            cell.remove(child)
+    cell.set("t", "inlineStr")
+    namespace = _namespace(cell)
+    inline = etree.Element(_qname(namespace, "is"))
+    text = etree.SubElement(inline, _qname(namespace, "t"))
+    text.text = patch.after
+    if patch.after != patch.after.strip() or "\n" in patch.after or "\t" in patch.after:
+        text.set(XML_SPACE, "preserve")
+    extension = _direct_child(cell, "extLst")
+    if extension is None:
+        cell.append(inline)
+    else:
+        cell.insert(cell.index(extension), inline)
+    styles.set_text_number_format(cell)
+
+
+def apply_sheet_view(root: etree._Element, patch: PatchOperation) -> None:
+    top_left, zoom = _view_payload(patch)
+    sheet_views = _direct_child(root, "sheetViews")
+    if sheet_views is None:
+        raise PatchValidationError("Worksheet has no sheetViews element")
+    views = [child for child in sheet_views if etree.QName(child).localname == "sheetView"]
+    if len(views) != 1:
+        raise PatchValidationError("Sheet-view repair requires exactly one sheetView")
+    view = views[0]
+    panes = [child for child in view if etree.QName(child).localname == "pane"]
+    if len(panes) > 1:
+        raise PatchValidationError("Sheet-view repair requires at most one pane")
+    if panes and top_left is not None:
+        raise PatchValidationError("Sheet-view origin repair refuses frozen or split panes")
+    if top_left is not None:
+        view.set("topLeftCell", top_left)
+    if zoom is not None:
+        view.set("zoomScale", str(zoom))
+
+
+def apply_copy_border(root: etree._Element, patch: PatchOperation, styles: StylesEditor) -> None:
+    if not patch.source_cell:
+        raise PatchValidationError(f"Border patch {patch.id} has no source cell")
+    target_coordinate = _validate_coordinate(patch.cell)
+    source_coordinate = _validate_coordinate(patch.source_cell, "source cell coordinate")
+    target = _cell_element_or_create(root, target_coordinate)
+    source = _cell_element(root, source_coordinate)
+    if source is None:
+        raise PatchValidationError("Border patch source cell is absent")
+    target_edge, source_edge = _border_payload(patch)
+    styles.copy_border_edge(
+        target,
+        source,
+        target_edge=target_edge,
+        source_edge=source_edge,
+    )
+
+
+def _reference_intersects_targets(
+    reference: str,
+    points: set[tuple[int, int]],
+    rows: set[int],
+    *,
+    include_rows: bool,
+    strict: bool = False,
+) -> bool:
+    """Return whether one unqualified A1 reference touches authorized tail state."""
+
+    normalized = reference.strip().lstrip("@").rstrip("#")
+    try:
+        min_column, min_row, max_column, max_row = range_boundaries(normalized)
+    except (TypeError, ValueError) as exc:
+        if strict:
+            raise PatchValidationError(f"Malformed OOXML range reference {reference!r}") from exc
+        return False
+    if include_rows and rows:
+        lower_row = 1 if min_row is None else min_row
+        upper_row = MAX_EXCEL_ROW if max_row is None else max_row
+        if any(lower_row <= row <= upper_row for row in rows):
+            return True
+    lower_column = 1 if min_column is None else min_column
+    upper_column = MAX_EXCEL_COLUMN if max_column is None else max_column
+    lower_row = 1 if min_row is None else min_row
+    upper_row = MAX_EXCEL_ROW if max_row is None else max_row
+    return any(
+        lower_row <= row <= upper_row and lower_column <= column <= upper_column
+        for row, column in points
+    )
+
+
+def _iter_direct_ranges(value: str) -> list[str]:
+    return [item for item in re.split(r"[\s,]+", value.strip()) if item]
+
+
+def _range_token_targets_sheet(
+    token: str,
+    *,
+    current_is_target: bool,
+    target_sheet_name: str,
+) -> tuple[bool, str]:
+    if "!" not in token:
+        return current_is_target, token
+    qualifier, reference = token.rsplit("!", 1)
+    qualifier = qualifier.strip()
+    if qualifier.startswith("'") and qualifier.endswith("'"):
+        qualifier = qualifier[1:-1].replace("''", "'")
+    if "[" in qualifier or "]" in qualifier:
+        return False, reference
+    if ":" in qualifier:
+        # Without reconstructing workbook sheet-order semantics, conservatively
+        # treat a matching 3-D cell/range reference as potentially targeting the sheet.
+        return True, reference
+    return qualifier.casefold() == target_sheet_name.casefold(), reference
+
+
+def _formula_range_tokens(expression: str, label: str) -> list[str]:
+    expression = expression[1:] if expression.startswith("=") else expression
+    try:
+        tokens = Tokenizer("=" + expression).items
+    except (TokenizerError, ValueError, IndexError) as exc:
+        raise PatchValidationError(f"Formatting-tail cleanup cannot safely parse {label}") from exc
+    for token in tokens:
+        if token.type != "FUNC" or token.subtype != "OPEN":
+            continue
+        function = token.value[:-1].upper().rsplit(".", maxsplit=1)[-1]
+        if function in {"INDIRECT", "OFFSET"}:
+            raise PatchValidationError(
+                f"Formatting-tail cleanup refuses dynamic reference function {function}"
+            )
+    return [token.value for token in tokens if token.type == "OPERAND" and token.subtype == "RANGE"]
+
+
+def _assert_no_formula_references(
+    archive: zipfile.ZipFile,
+    target_part: str,
+    target_sheet_name: str,
+    points: set[tuple[int, int]],
+    rows: set[int],
+) -> None:
+    from workbooklens.ooxml.safety import parse_xml_part
+
+    formula_parts = {
+        name: name == target_part
+        for name in archive.namelist()
+        if (name.startswith("xl/worksheets/") or name.startswith("xl/tables/"))
+        and name.endswith(".xml")
+        and "/_rels/" not in name
+    }
+    for relationship_type, related_part in _related_parts(archive, target_part):
+        if relationship_type.endswith("/table"):
+            formula_parts[related_part] = True
+    for formula_part, current_is_target in sorted(formula_parts.items()):
+        root = parse_xml_part(archive.read(formula_part), formula_part)
+        for formula in root.iter():
+            if (
+                etree.QName(formula).localname
+                not in {
+                    "f",
+                    "formula",
+                    "formula1",
+                    "formula2",
+                    "calculatedColumnFormula",
+                    "totalsRowFormula",
+                }
+                or not formula.text
+            ):
+                continue
+            for token in _formula_range_tokens(
+                formula.text,
+                f"formula in {formula_part}",
+            ):
+                targets_sheet, reference = _range_token_targets_sheet(
+                    token,
+                    current_is_target=current_is_target,
+                    target_sheet_name=target_sheet_name,
+                )
+                if targets_sheet and _reference_intersects_targets(
+                    reference,
+                    points,
+                    rows,
+                    include_rows=True,
+                ):
+                    raise PatchValidationError(
+                        "Formatting-tail target is referenced by a worksheet formula"
+                    )
+
+
+def _assert_no_direct_references(
+    root: etree._Element,
+    points: set[tuple[int, int]],
+    rows: set[int],
+) -> None:
+    reference_attributes = {
+        "mergeCell": "ref",
+        "hyperlink": "ref",
+        "conditionalFormatting": "sqref",
+        "dataValidation": "sqref",
+        "autoFilter": "ref",
+        "protectedRange": "sqref",
+        "ignoredError": "sqref",
+        "sortState": "ref",
+        "sortCondition": "ref",
+        "f": "ref",
+    }
+    for element in root.iter():
+        local_name = etree.QName(element).localname
+        attribute = reference_attributes.get(local_name)
+        if attribute is None:
+            continue
+        value = element.get(attribute)
+        if not value:
+            continue
+        for reference in _iter_direct_ranges(value):
+            if _reference_intersects_targets(
+                reference,
+                points,
+                rows,
+                include_rows=True,
+                strict=True,
+            ):
+                raise PatchValidationError(f"Formatting-tail target is referenced by {local_name}")
+
+
+def _assert_no_page_break_references(
+    root: etree._Element,
+    points: set[tuple[int, int]],
+    rows: set[int],
+) -> None:
+    target_rows = rows | {row for row, _ in points}
+    target_columns = {column for _, column in points}
+    for collection_name, targets, maximum in (
+        ("rowBreaks", target_rows, MAX_EXCEL_ROW),
+        ("colBreaks", target_columns, MAX_EXCEL_COLUMN),
+    ):
+        collection = _direct_child(root, collection_name)
+        if collection is None:
+            continue
+        for child in collection:
+            if etree.QName(child).localname != "brk":
+                raise PatchValidationError(
+                    f"{collection_name} contains an unsupported child element"
+                )
+            try:
+                break_id = int(cast(str, child.get("id")))
+            except (TypeError, ValueError) as exc:
+                raise PatchValidationError(
+                    f"{collection_name} contains an invalid break id"
+                ) from exc
+            if not 0 <= break_id <= maximum:
+                raise PatchValidationError(f"{collection_name} break id is outside Excel bounds")
+            if break_id in targets:
+                raise PatchValidationError(f"Formatting-tail target intersects {collection_name}")
+
+
+def _relationship_part_name(part: str) -> str:
+    return posixpath.join(
+        posixpath.dirname(part),
+        "_rels",
+        posixpath.basename(part) + ".rels",
+    )
+
+
+def _resolve_relationship_target(part: str, target: str) -> str:
+    if not target or "\\" in target or "\x00" in target:
+        raise PatchValidationError(f"Unsafe relationship target: {target!r}")
+    if target.startswith("/"):
+        candidate = target.lstrip("/")
+    else:
+        candidate = posixpath.join(posixpath.dirname(part), target)
+    normalized = posixpath.normpath(candidate)
+    if normalized in {"", ".", ".."} or normalized.startswith("../"):
+        raise PatchValidationError(f"Relationship target escapes package root: {target!r}")
+    return normalized
+
+
+def _related_parts(archive: zipfile.ZipFile, part: str) -> list[tuple[str, str]]:
+    relationship_name = _relationship_part_name(part)
+    if relationship_name not in archive.namelist():
+        return []
+    from workbooklens.ooxml.safety import parse_xml_part
+
+    root = parse_xml_part(archive.read(relationship_name), relationship_name)
+    result: list[tuple[str, str]] = []
+    for relationship in root:
+        if etree.QName(relationship).localname != "Relationship":
+            continue
+        if relationship.get("TargetMode") == "External":
+            continue
+        target = relationship.get("Target")
+        relationship_type = relationship.get("Type", "")
+        if target:
+            result.append((relationship_type, _resolve_relationship_target(part, target)))
+    return result
+
+
+def _assert_no_related_references(
+    archive: zipfile.ZipFile,
+    part: str,
+    points: set[tuple[int, int]],
+    rows: set[int],
+) -> None:
+    from workbooklens.ooxml.safety import parse_xml_part
+
+    for relationship_type, target in _related_parts(archive, part):
+        if target not in archive.namelist():
+            raise PatchValidationError(f"Worksheet relationship target is missing: {target}")
+        if relationship_type.endswith(("/comments", "/threadedComment", "/threadedComments")):
+            root = parse_xml_part(archive.read(target), target)
+            for element in root.iter():
+                reference = element.get("ref")
+                if reference and _reference_intersects_targets(
+                    reference,
+                    points,
+                    rows,
+                    include_rows=True,
+                    strict=True,
+                ):
+                    raise PatchValidationError("Formatting-tail target has an attached comment")
+        elif relationship_type.endswith("/table"):
+            root = parse_xml_part(archive.read(target), target)
+            reference = root.get("ref")
+            if reference and _reference_intersects_targets(
+                reference,
+                points,
+                rows,
+                include_rows=True,
+                strict=True,
+            ):
+                raise PatchValidationError("Formatting-tail target intersects an Excel table")
+        elif relationship_type.endswith("/drawing"):
+            root = parse_xml_part(archive.read(target), target)
+            for anchor in root:
+                if etree.QName(anchor).localname not in {
+                    "oneCellAnchor",
+                    "twoCellAnchor",
+                    "absoluteAnchor",
+                }:
+                    continue
+                if etree.QName(anchor).localname == "absoluteAnchor":
+                    raise PatchValidationError(
+                        "Formatting-tail cleanup refuses worksheets with absolute drawings"
+                    )
+                markers = [
+                    child for child in anchor if etree.QName(child).localname in {"from", "to"}
+                ]
+                if not markers:
+                    continue
+                positions: list[tuple[int, int]] = []
+                for marker in markers:
+                    row_node = _direct_child(marker, "row")
+                    col_node = _direct_child(marker, "col")
+                    if row_node is None or col_node is None:
+                        raise PatchValidationError("Drawing anchor is malformed")
+                    try:
+                        positions.append(
+                            (int(row_node.text or "") + 1, int(col_node.text or "") + 1)
+                        )
+                    except ValueError as exc:
+                        raise PatchValidationError("Drawing anchor is malformed") from exc
+                min_row = min(row for row, _ in positions)
+                max_row = max(row for row, _ in positions)
+                min_col = min(column for _, column in positions)
+                max_col = max(column for _, column in positions)
+                if _reference_intersects_targets(
+                    (
+                        f"{get_column_letter(min_col)}{min_row}:"
+                        f"{get_column_letter(max_col)}{max_row}"
+                    ),
+                    points,
+                    rows,
+                    include_rows=True,
+                ):
+                    raise PatchValidationError("Formatting-tail target intersects a drawing")
+        elif relationship_type.endswith("/vmlDrawing"):
+            raise PatchValidationError(
+                "Formatting-tail cleanup refuses worksheets with VML drawings"
+            )
+
+
+def _assert_no_defined_name_references(
+    archive: zipfile.ZipFile,
+    sheet_name: str,
+    points: set[tuple[int, int]],
+    rows: set[int],
+) -> None:
+    from workbooklens.ooxml.safety import parse_xml_part
+
+    root = parse_xml_part(archive.read("xl/workbook.xml"), "xl/workbook.xml")
+    sheets = _direct_child(root, "sheets")
+    sheet_names = [child.get("name") for child in sheets] if sheets is not None else []
+    try:
+        target_sheet_index = sheet_names.index(sheet_name)
+    except ValueError as exc:
+        raise PatchValidationError(
+            "Formatting-tail worksheet is missing from workbook.xml"
+        ) from exc
+    for element in root.iter():
+        if etree.QName(element).localname != "definedName" or not element.text:
+            continue
+        local_sheet_id = element.get("localSheetId")
+        if local_sheet_id is None:
+            unqualified_targets_sheet = True
+        else:
+            try:
+                unqualified_targets_sheet = int(local_sheet_id) == target_sheet_index
+            except ValueError as exc:
+                raise PatchValidationError(
+                    "Workbook defined name has an invalid localSheetId"
+                ) from exc
+        for token in _formula_range_tokens(element.text, "workbook defined name"):
+            targets_sheet, reference = _range_token_targets_sheet(
+                token,
+                current_is_target=unqualified_targets_sheet,
+                target_sheet_name=sheet_name,
+            )
+            if targets_sheet and _reference_intersects_targets(
+                reference,
+                points,
+                rows,
+                include_rows=True,
+            ):
+                raise PatchValidationError(
+                    "Formatting-tail target is referenced by a workbook defined name"
+                )
+
+
+def _recompute_spans(root: etree._Element) -> None:
+    sheet_data = _direct_child(root, "sheetData")
+    if sheet_data is None:
+        raise PatchValidationError("Worksheet has no sheetData element")
+    for row in sheet_data:
+        if etree.QName(row).localname != "row":
+            continue
+        columns: list[int] = []
+        for cell in row:
+            if etree.QName(cell).localname != "c":
+                continue
+            coordinate = cell.get("r")
+            if not coordinate:
+                raise PatchValidationError("Worksheet cell is missing its coordinate")
+            _, column = coordinate_to_tuple(coordinate)
+            columns.append(column)
+        if columns:
+            row.set("spans", f"{min(columns)}:{max(columns)}")
+        else:
+            if "spans" in row.attrib:
+                del row.attrib["spans"]
+
+
+def _computed_dimension(root: etree._Element) -> str:
+    bounds: list[tuple[int, int, int, int]] = []
+    for element in root.iter():
+        local_name = etree.QName(element).localname
+        if local_name == "c" and element.get("r"):
+            row, column = coordinate_to_tuple(cast(str, element.get("r")))
+            bounds.append((column, row, column, row))
+        elif local_name == "mergeCell" and element.get("ref"):
+            try:
+                merged_bounds = range_boundaries(cast(str, element.get("ref")))
+            except ValueError as exc:
+                raise PatchValidationError("Worksheet contains an invalid merged range") from exc
+            if any(value is None for value in merged_bounds):
+                raise PatchValidationError("Worksheet contains a non-cell merged range")
+            bounds.append(cast(tuple[int, int, int, int], merged_bounds))
+    if not bounds:
+        return "A1"
+    min_column = min(minimum for minimum, _, _, _ in bounds)
+    min_row = min(minimum for _, minimum, _, _ in bounds)
+    max_column = max(maximum for _, _, maximum, _ in bounds)
+    max_row = max(maximum for _, _, _, maximum in bounds)
+    start = f"{get_column_letter(min_column)}{min_row}"
+    end = f"{get_column_letter(max_column)}{max_row}"
+    return start if start == end else f"{start}:{end}"
+
+
+def _dimensions_equivalent(left: str, right: str) -> bool:
+    """Compare worksheet dimensions by cell bounds, not lexical spelling."""
+
+    return CellRange(left).bounds == CellRange(right).bounds
+
+
+def _simple_whitespace_cell_text(
+    archive: zipfile.ZipFile,
+    cell: etree._Element,
+) -> str:
+    unsupported_attributes = {str(name) for name in cell.attrib} - {"r", "s", "t"}
+    if unsupported_attributes:
+        raise PatchValidationError("Whitespace-tail cell contains unsupported metadata")
+    child_names = [etree.QName(child).localname for child in cell]
+    if "f" in child_names or "extLst" in child_names:
+        raise PatchValidationError("Whitespace-tail cell contains a formula or extension")
+    cell_type = cell.get("t")
+    if cell_type == "s":
+        if child_names != ["v"] or "xl/sharedStrings.xml" not in archive.namelist():
+            raise PatchValidationError("Whitespace-tail shared-string cell is malformed")
+        try:
+            index = int(cell[0].text or "")
+        except ValueError as exc:
+            raise PatchValidationError("Whitespace-tail shared-string index is invalid") from exc
+        from workbooklens.ooxml.safety import parse_xml_part
+
+        root = parse_xml_part(archive.read("xl/sharedStrings.xml"), "xl/sharedStrings.xml")
+        strings = [child for child in root if etree.QName(child).localname == "si"]
+        if not 0 <= index < len(strings):
+            raise PatchValidationError("Whitespace-tail shared-string index is out of bounds")
+        item = strings[index]
+        item_children = [child for child in item if etree.QName(child).localname == "t"]
+        if len(item_children) != 1 or len(item) != 1:
+            raise PatchValidationError("Whitespace-tail cleanup refuses rich shared strings")
+        return item_children[0].text or ""
+    if cell_type == "inlineStr":
+        if child_names != ["is"]:
+            raise PatchValidationError("Whitespace-tail inline string is malformed")
+        inline = cell[0]
+        texts = [child for child in inline if etree.QName(child).localname == "t"]
+        if len(texts) != 1 or len(inline) != 1:
+            raise PatchValidationError("Whitespace-tail cleanup refuses rich inline strings")
+        return texts[0].text or ""
+    if cell_type == "str" and child_names == ["v"]:
+        return cell[0].text or ""
+    raise PatchValidationError("Whitespace-tail target is not a supported literal string")
+
+
+def _cell_style_id(cell: etree._Element) -> int:
+    """Return an OOXML cell style index, rejecting malformed or negative values."""
+
+    raw_style_id = cell.get("s")
+    if raw_style_id is None:
+        return 0
+    try:
+        style_id = int(raw_style_id)
+    except ValueError as exc:
+        raise PatchValidationError("Whitespace-tail cell style index is invalid") from exc
+    if style_id < 0:
+        raise PatchValidationError("Whitespace-tail cell style index is invalid")
+    return style_id
+
+
+def apply_clear_formatting_tail(
+    archive: zipfile.ZipFile,
+    part: str,
+    sheet_name: str,
+    root: etree._Element,
+    patch: PatchOperation,
+) -> None:
+    cells, empty_rows, expected_dimension, result_dimension = _tail_payload(patch)
+    dimension = _direct_child(root, "dimension")
+    if dimension is None or dimension.get("ref") != expected_dimension:
+        raise PatchValidationError("Formatting-tail expected_dimension does not match OOXML")
+    points = {coordinate_to_tuple(coordinate) for coordinate in cells}
+    rows = set(empty_rows)
+    _assert_no_direct_references(root, points, rows)
+    _assert_no_page_break_references(root, points, rows)
+    _assert_no_formula_references(archive, part, sheet_name, points, rows)
+    _assert_no_related_references(archive, part, points, rows)
+    _assert_no_defined_name_references(archive, sheet_name, points, rows)
+    for coordinate in cells:
+        cell = _cell_element(root, coordinate)
+        if cell is None:
+            raise PatchValidationError(f"Authorized formatting-tail cell is absent: {coordinate}")
+        if cell.get("s") is None:
+            raise PatchValidationError(
+                f"Formatting-tail cell has no explicit style to clear: {coordinate}"
+            )
+        unsupported_cell_attributes = {str(name) for name in cell.attrib} - {"r", "s", "t"}
+        type_value = cell.get("t")
+        if (
+            len(cell)
+            or unsupported_cell_attributes
+            or (type_value is not None and type_value != "n")
+        ):
+            raise PatchValidationError(
+                f"Formatting-tail cell {coordinate} contains value, formula, metadata, or extension data"
+            )
+        parent = cell.getparent()
+        if parent is None or etree.QName(parent).localname != "row":
+            raise PatchValidationError("Formatting-tail cell has no worksheet row parent")
+        parent.remove(cell)
+    sheet_data = _direct_child(root, "sheetData")
+    if sheet_data is None:
+        raise PatchValidationError("Worksheet has no sheetData element")
+    for row_number in empty_rows:
+        row = _row_element(root, row_number)
+        if row is None:
+            raise PatchValidationError(f"Authorized empty tail row is absent: {row_number}")
+        if len(row):
+            raise PatchValidationError(f"Formatting-tail row {row_number} is not empty")
+        allowed_attributes = {"r", "spans", "ht", "customHeight", "s", "customFormat"}
+        unsupported_row_attributes = {str(name) for name in row.attrib} - allowed_attributes
+        if unsupported_row_attributes:
+            raise PatchValidationError(
+                f"Formatting-tail row {row_number} has unsupported attributes: "
+                + ", ".join(sorted(unsupported_row_attributes))
+            )
+        if row.get("ht") is not None or row.get("customHeight") in {"1", "true"}:
+            raise PatchValidationError("Formatting-tail cleanup refuses custom-height rows")
+        if row.get("hidden") in {"1", "true"} or row.get("collapsed") in {"1", "true"}:
+            raise PatchValidationError("Formatting-tail cleanup refuses hidden or collapsed rows")
+        if int(row.get("outlineLevel", "0")) != 0:
+            raise PatchValidationError("Formatting-tail cleanup refuses outlined rows")
+        sheet_data.remove(row)
+    _recompute_spans(root)
+    computed = _computed_dimension(root)
+    if not _dimensions_equivalent(computed, result_dimension):
+        raise PatchValidationError(
+            f"Formatting-tail result_dimension mismatch: computed {computed}, authorized {result_dimension}"
+        )
+    dimension.set("ref", computed)
+
+
+def apply_remove_whitespace_tail_cells(
+    archive: zipfile.ZipFile,
+    part: str,
+    sheet_name: str,
+    root: etree._Element,
+    patch: PatchOperation,
+) -> None:
+    cells, preserve_style_ids, expected_dimension, result_dimension = _whitespace_tail_payload(
+        patch
+    )
+    dimension = _direct_child(root, "dimension")
+    dimension_reference = dimension.get("ref") if dimension is not None else None
+    if (
+        dimension is None
+        or not isinstance(dimension_reference, str)
+        or not _dimensions_equivalent(dimension_reference, expected_dimension)
+    ):
+        raise PatchValidationError("Whitespace-tail expected_dimension does not match OOXML")
+    points = {coordinate_to_tuple(coordinate) for coordinate in cells}
+    rows: set[int] = set()
+    _assert_no_direct_references(root, points, rows)
+    _assert_no_page_break_references(root, points, rows)
+    _assert_no_formula_references(archive, part, sheet_name, points, rows)
+    _assert_no_related_references(archive, part, points, rows)
+    _assert_no_defined_name_references(archive, sheet_name, points, rows)
+    for coordinate in cells:
+        cell = _cell_element(root, coordinate)
+        if cell is None:
+            raise PatchValidationError(f"Authorized whitespace-tail cell is absent: {coordinate}")
+        text = _simple_whitespace_cell_text(archive, cell)
+        if not text or text.strip() or any(character in "\r\n\t" for character in text):
+            raise PatchValidationError(
+                f"Whitespace-tail cell is no longer simple literal whitespace: {coordinate}"
+            )
+        style_id = _cell_style_id(cell)
+        preserved_style_id = preserve_style_ids.get(coordinate)
+        if preserved_style_id is None and style_id != 0:
+            raise PatchValidationError(
+                f"Whitespace-tail cell has an unauthorized non-default style: {coordinate}"
+            )
+        if preserved_style_id is not None and style_id != preserved_style_id:
+            raise PatchValidationError(
+                f"Whitespace-tail cell style no longer matches its authorization: {coordinate}"
+            )
+        parent = cell.getparent()
+        if parent is None or etree.QName(parent).localname != "row":
+            raise PatchValidationError("Whitespace-tail cell has no worksheet row parent")
+        if preserved_style_id is None:
+            parent.remove(cell)
+        else:
+            for child in list(cell):
+                cell.remove(child)
+            if "t" in cell.attrib:
+                del cell.attrib["t"]
+    _recompute_spans(root)
+    computed = _computed_dimension(root)
+    if not _dimensions_equivalent(computed, result_dimension):
+        raise PatchValidationError(
+            f"Whitespace-tail result_dimension mismatch: computed {computed}, authorized {result_dimension}"
+        )
+    dimension.set("ref", computed)
+
+
+def validate_layout_semantics(
+    worksheet: Worksheet,
+    patch: PatchOperation,
+) -> None:
+    """Verify openpyxl observes the requested layout result after package rewrite."""
+
+    if patch.kind == PatchKind.SET_COLUMN_WIDTH:
+        column, width = _column_payload(patch)
+        key = get_column_letter(column)
+        dimension = next(
+            (
+                item
+                for item in worksheet.column_dimensions.values()
+                if item.min is not None and item.max is not None and item.min <= column <= item.max
+            ),
+            None,
+        )
+        if (
+            dimension is None
+            or dimension.width is None
+            or not math.isclose(float(dimension.width), width, rel_tol=0.0, abs_tol=1e-9)
+        ):
+            raise PatchValidationError(f"Column-width verification failed for {key}")
+    elif patch.kind == PatchKind.SET_ROW_HEIGHT:
+        row, height = _row_payload(patch)
+        observed = worksheet.row_dimensions[row].height
+        if observed is None or not math.isclose(float(observed), height, rel_tol=0.0, abs_tol=1e-9):
+            raise PatchValidationError(f"Row-height verification failed for row {row}")
+    elif patch.kind == PatchKind.SET_WRAP_TEXT:
+        if bool(worksheet[patch.cell].alignment.wrap_text) != _boolean_payload(patch, "wrap_text"):
+            raise PatchValidationError(f"Wrap-text verification failed for patch {patch.id}")
+    elif patch.kind == PatchKind.SET_SHRINK_TO_FIT:
+        if bool(worksheet[patch.cell].alignment.shrink_to_fit) != _boolean_payload(
+            patch, "shrink_to_fit"
+        ):
+            raise PatchValidationError(f"Shrink-to-fit verification failed for patch {patch.id}")
+    elif patch.kind == PatchKind.SET_TEXT:
+        cell = worksheet[patch.cell]
+        if cell.value != patch.after or cell.data_type != "s" or cell.number_format != "@":
+            raise PatchValidationError(f"Text verification failed for patch {patch.id}")
+    elif patch.kind == PatchKind.SET_SHEET_VIEW:
+        top_left, zoom = _view_payload(patch)
+        if top_left is not None and worksheet.sheet_view.topLeftCell != top_left:
+            raise PatchValidationError(f"Sheet-view verification failed for patch {patch.id}")
+        if zoom is not None and worksheet.sheet_view.zoomScale != zoom:
+            raise PatchValidationError(f"Sheet-view zoom verification failed for patch {patch.id}")
+    elif patch.kind == PatchKind.COPY_BORDER:
+        if not patch.source_cell:
+            raise PatchValidationError(f"Border patch {patch.id} has no source cell")
+        target_edge, source_edge = _border_payload(patch)
+        target_side = getattr(worksheet[patch.cell].border, target_edge)
+        source_side = getattr(worksheet[patch.source_cell].border, source_edge)
+        if target_side != source_side:
+            raise PatchValidationError(f"Border verification failed for patch {patch.id}")
+    elif patch.kind == PatchKind.CLEAR_FORMATTING_TAIL:
+        cells, rows, _, result = _tail_payload(patch)
+        for coordinate in cells:
+            row, column = coordinate_to_tuple(coordinate)
+            if (row, column) in worksheet._cells:
+                raise PatchValidationError(
+                    f"Formatting-tail cell remains after repair: {coordinate}"
+                )
+        for row in rows:
+            if row in worksheet.row_dimensions:
+                raise PatchValidationError(f"Formatting-tail row remains after repair: {row}")
+        if not _dimensions_equivalent(worksheet.calculate_dimension(), result):
+            raise PatchValidationError("Formatting-tail dimension verification failed")
+    elif patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS:
+        cells, preserve_style_ids, _, result = _whitespace_tail_payload(patch)
+        for coordinate in cells:
+            row, column = coordinate_to_tuple(coordinate)
+            cell = worksheet._cells.get((row, column))
+            expected_style_id = preserve_style_ids.get(coordinate)
+            if expected_style_id is None and cell is not None:
+                raise PatchValidationError(
+                    f"Whitespace-tail cell remains after repair: {coordinate}"
+                )
+            if expected_style_id is not None and (
+                cell is None or cell.value is not None or cell.style_id != expected_style_id
+            ):
+                raise PatchValidationError(
+                    f"Whitespace-tail style preservation failed after repair: {coordinate}"
+                )
+        if not _dimensions_equivalent(worksheet.calculate_dimension(), result):
+            raise PatchValidationError("Whitespace-tail dimension verification failed")
+
+
+__all__ = [
+    "LAYOUT_KINDS",
+    "StylesEditor",
+    "apply_alignment",
+    "apply_clear_formatting_tail",
+    "apply_column_width",
+    "apply_copy_border",
+    "apply_remove_whitespace_tail_cells",
+    "apply_row_height",
+    "apply_set_text",
+    "apply_sheet_view",
+    "is_layout_kind",
+    "needs_styles",
+    "patch_target_key",
+    "tail_authorization",
+    "validate_layout_semantics",
+    "verify_layout_precondition",
+    "whitespace_tail_authorization",
+    "whitespace_tail_preserved_style_ids",
+]

--- a/src/workbooklens/repair/ooxml_patch.py
+++ b/src/workbooklens/repair/ooxml_patch.py
@@ -17,13 +17,32 @@ from typing import Any, cast
 from lxml import etree
 from openpyxl import load_workbook
 from openpyxl.cell.cell import Cell
-from openpyxl.utils.cell import coordinate_to_tuple
+from openpyxl.utils.cell import coordinate_to_tuple, get_column_letter
 from openpyxl.worksheet.cell_range import CellRange
 
 from workbooklens.exceptions import PatchValidationError, StalePlanError, UsageError
 from workbooklens.formulas import analyze_formula
 from workbooklens.models import PackageChange, PatchKind, PatchOperation, PatchPlan
 from workbooklens.ooxml.safety import PackageLimits, inspect_package, parse_xml_part
+from workbooklens.repair.layout_ooxml import (
+    StylesEditor,
+    apply_alignment,
+    apply_clear_formatting_tail,
+    apply_column_width,
+    apply_copy_border,
+    apply_remove_whitespace_tail_cells,
+    apply_row_height,
+    apply_set_text,
+    apply_sheet_view,
+    is_layout_kind,
+    needs_styles,
+    patch_target_key,
+    tail_authorization,
+    validate_layout_semantics,
+    verify_layout_precondition,
+    whitespace_tail_authorization,
+    whitespace_tail_preserved_style_ids,
+)
 from workbooklens.snapshot import cell_fingerprint, load_for_analysis
 from workbooklens.utils import sha256_file
 from workbooklens.worksheet_state import is_column_hidden
@@ -210,7 +229,12 @@ def _assert_not_in_advanced_formula_range(root: etree._Element, coordinate: str)
             )
 
 
-def _assert_not_in_merged_range(root: etree._Element, coordinate: str) -> None:
+def _assert_not_in_merged_range(
+    root: etree._Element,
+    coordinate: str,
+    *,
+    allow_anchor: bool = False,
+) -> None:
     for element in root.iter():
         if etree.QName(element).localname != "mergeCell":
             continue
@@ -222,6 +246,9 @@ def _assert_not_in_merged_range(root: etree._Element, coordinate: str) -> None:
         except ValueError as exc:
             raise PatchValidationError(f"Invalid merged range {reference!r}") from exc
         if coordinate in merged:
+            anchor = f"{get_column_letter(merged.min_col)}{merged.min_row}"
+            if allow_anchor and coordinate == anchor:
+                return
             raise PatchValidationError(
                 f"target {coordinate} intersects merged range {reference}; automatic patches are refused"
             )
@@ -281,21 +308,27 @@ def _update_dimension(root: etree._Element) -> None:
     ]
     if not cells:
         return
-    coordinates = [coordinate_to_tuple(cast(str, coordinate)) for coordinate in cells]
-    min_row = min(item[0] for item in coordinates)
-    max_row = max(item[0] for item in coordinates)
-    min_column = min(item[1] for item in coordinates)
-    max_column = max(item[1] for item in coordinates)
-    from openpyxl.utils.cell import get_column_letter
-
-    start = f"{get_column_letter(min_column)}{min_row}"
-    end = f"{get_column_letter(max_column)}{max_row}"
     dimension = next(
         (element for element in root if etree.QName(element).localname == "dimension"),
         None,
     )
-    if dimension is not None:
-        dimension.set("ref", start if start == end else f"{start}:{end}")
+    if dimension is None:
+        return
+    existing_ref = dimension.get("ref")
+    if not existing_ref:
+        raise PatchValidationError("Worksheet dimension is missing its ref attribute")
+    try:
+        existing = CellRange(existing_ref)
+    except (TypeError, ValueError) as exc:
+        raise PatchValidationError("Worksheet dimension ref is malformed") from exc
+    coordinates = [coordinate_to_tuple(cast(str, coordinate)) for coordinate in cells]
+    min_row = min(existing.min_row, *(item[0] for item in coordinates))
+    max_row = max(existing.max_row, *(item[0] for item in coordinates))
+    min_column = min(existing.min_col, *(item[1] for item in coordinates))
+    max_column = max(existing.max_col, *(item[1] for item in coordinates))
+    start = f"{get_column_letter(min_column)}{min_row}"
+    end = f"{get_column_letter(max_column)}{max_row}"
+    dimension.set("ref", start if start == end else f"{start}:{end}")
 
 
 def _serialize_xml(root: etree._Element) -> bytes:
@@ -351,6 +384,7 @@ def _verify_preconditions(
                 raise StalePlanError(
                     f"Cell precondition failed for {patch.sheet}!{patch.cell}; plan is stale"
                 )
+            verify_layout_precondition(worksheet, patch)
             if worksheet.protection.sheet:
                 raise PatchValidationError(
                     f"Patch target is on protected worksheet {patch.sheet!r}; unprotect it before repair"
@@ -369,6 +403,94 @@ def _verify_preconditions(
                     f"Patch target is in a hidden column at {patch.sheet}!{patch.cell}; "
                     "unhide it before repair"
                 )
+            if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL:
+                tail_cells, tail_rows = tail_authorization(patch)
+                for coordinate in tail_cells:
+                    tail_cell = worksheet[coordinate]
+                    if not isinstance(tail_cell, Cell):
+                        raise PatchValidationError(
+                            f"Formatting-tail target is not a cell: {patch.sheet}!{coordinate}"
+                        )
+                    if tail_cell.value is not None:
+                        raise PatchValidationError(
+                            f"Formatting-tail target contains a value: {patch.sheet}!{coordinate}"
+                        )
+                    if tail_cell.comment is not None or tail_cell.hyperlink is not None:
+                        raise PatchValidationError(
+                            f"Formatting-tail target has a comment or hyperlink: "
+                            f"{patch.sheet}!{coordinate}"
+                        )
+                    row_dimension = worksheet.row_dimensions.get(tail_cell.row)
+                    if row_dimension is not None and row_dimension.hidden:
+                        raise PatchValidationError(
+                            f"Formatting-tail target is on hidden row {patch.sheet}!{tail_cell.row}"
+                        )
+                    if is_column_hidden(worksheet, tail_cell.column):
+                        raise PatchValidationError(
+                            f"Formatting-tail target is in hidden column {patch.sheet}!{coordinate}"
+                        )
+                for row in tail_rows:
+                    dimension = worksheet.row_dimensions.get(row)
+                    if dimension is None:
+                        raise PatchValidationError(
+                            f"Formatting-tail row is absent: {patch.sheet}!{row}"
+                        )
+                    if dimension.hidden or dimension.collapsed or dimension.outlineLevel:
+                        raise PatchValidationError(
+                            f"Formatting-tail cleanup refuses hidden, collapsed, or outlined row {row}"
+                        )
+            if patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS:
+                preserve_style_ids = whitespace_tail_preserved_style_ids(patch)
+                for coordinate in whitespace_tail_authorization(patch):
+                    target = worksheet[coordinate]
+                    if not isinstance(target, Cell):
+                        raise PatchValidationError(
+                            f"Whitespace-tail target is not a cell: {patch.sheet}!{coordinate}"
+                        )
+                    value = target.value
+                    if (
+                        target.data_type != "s"
+                        or not isinstance(value, str)
+                        or not value
+                        or value.strip()
+                        or any(character in "\r\n\t" for character in value)
+                        or target.quotePrefix
+                        or (target.number_format or "General").strip().casefold() != "general"
+                    ):
+                        raise PatchValidationError(
+                            f"Whitespace-tail target is no longer simple literal whitespace: "
+                            f"{patch.sheet}!{coordinate}"
+                        )
+                    if target.comment is not None or target.hyperlink is not None:
+                        raise PatchValidationError(
+                            f"Whitespace-tail target has a comment or hyperlink: "
+                            f"{patch.sheet}!{coordinate}"
+                        )
+                    expected_style_id = preserve_style_ids.get(coordinate)
+                    if expected_style_id is None and target.style_id != 0:
+                        raise PatchValidationError(
+                            f"Whitespace-tail target has an unauthorized non-default style: "
+                            f"{patch.sheet}!{coordinate}"
+                        )
+                    if expected_style_id is not None and target.style_id != expected_style_id:
+                        raise PatchValidationError(
+                            f"Whitespace-tail target style no longer matches its authorization: "
+                            f"{patch.sheet}!{coordinate}"
+                        )
+                    row_dimension = worksheet.row_dimensions.get(target.row)
+                    if row_dimension is not None and row_dimension.hidden:
+                        raise PatchValidationError(
+                            f"Whitespace-tail target is on hidden row {patch.sheet}!{target.row}"
+                        )
+                    if is_column_hidden(worksheet, target.column):
+                        raise PatchValidationError(
+                            f"Whitespace-tail target is in hidden column {patch.sheet}!{coordinate}"
+                        )
+                    if any(coordinate in merged for merged in worksheet.merged_cells.ranges):
+                        raise PatchValidationError(
+                            f"Whitespace-tail target intersects a merged range: "
+                            f"{patch.sheet}!{coordinate}"
+                        )
             if patch.kind == PatchKind.COPY_STYLE:
                 if not patch.source_cell:
                     raise PatchValidationError(f"Style patch {patch.id} has no source cell")
@@ -397,6 +519,25 @@ def _verify_preconditions(
                     raise PatchValidationError(
                         f"Style patch {patch.id} would change pivot-button semantics"
                     )
+            elif patch.kind == PatchKind.COPY_BORDER:
+                if not patch.source_cell:
+                    raise PatchValidationError(f"Border patch {patch.id} has no source cell")
+                source_cell = worksheet[patch.source_cell]
+                if not isinstance(source_cell, Cell):
+                    raise PatchValidationError(
+                        f"Border patch source is not a writable cell: "
+                        f"{patch.sheet}!{patch.source_cell}"
+                    )
+                source_row = worksheet.row_dimensions.get(source_cell.row)
+                if source_row is not None and source_row.hidden:
+                    raise PatchValidationError(
+                        f"Border patch source is on hidden row {patch.sheet}!{source_cell.row}"
+                    )
+                if is_column_hidden(worksheet, source_cell.column):
+                    raise PatchValidationError(
+                        f"Border patch source is in a hidden column: "
+                        f"{patch.sheet}!{patch.source_cell}"
+                    )
     finally:
         workbook.close()
 
@@ -407,6 +548,7 @@ def _select_patches(
     safe_only: bool,
     *,
     enforce_safety: bool = True,
+    accept_layout_risk: bool = False,
 ) -> list[PatchOperation]:
     by_id = {patch.id: patch for patch in plan.patches}
     if len(by_id) != len(plan.patches):
@@ -414,9 +556,21 @@ def _select_patches(
     if safe_only and selected_ids:
         raise UsageError("--safe-only and --patch-id are mutually exclusive")
     if safe_only:
-        selected = [
-            patch for patch in plan.patches if patch.safe and float(patch.confidence) >= 0.95
-        ]
+        selected = [patch for patch in plan.patches if patch.safe_only_eligible]
+        selected_set = {patch.id for patch in selected}
+        incomplete_safe_groups = {
+            patch.atomic_group
+            for patch in selected
+            if patch.atomic_group
+            and any(
+                member.atomic_group == patch.atomic_group and member.id not in selected_set
+                for member in plan.patches
+            )
+        }
+        if incomplete_safe_groups:
+            selected = [
+                patch for patch in selected if patch.atomic_group not in incomplete_safe_groups
+            ]
     else:
         if not selected_ids:
             raise UsageError("Select at least one --patch-id or pass --safe-only")
@@ -427,18 +581,39 @@ def _select_patches(
     if not selected:
         raise UsageError("No eligible patches were selected")
     if enforce_safety:
-        unsafe = [
-            patch.id for patch in selected if not patch.safe or float(patch.confidence) < 0.95
-        ]
-        if unsafe:
+        rejected: list[str] = []
+        for patch in selected:
+            risk = str(getattr(patch.risk, "value", patch.risk))
+            if risk == "layout_review":
+                if safe_only or not accept_layout_risk or float(patch.confidence) < 0.95:
+                    rejected.append(patch.id)
+                continue
+            if not patch.safe or float(patch.confidence) < 0.95:
+                rejected.append(patch.id)
+        if rejected:
             raise UsageError(
-                "WorkbookLens 2.1 refuses patches below the safe 0.95 threshold: "
-                + ", ".join(unsafe)
+                "WorkbookLens refuses patches outside the authorized repair risk boundary: "
+                + ", ".join(rejected)
             )
+    selected_set = {patch.id for patch in selected}
+    incomplete_groups = sorted(
+        {
+            patch.atomic_group
+            for patch in selected
+            if patch.atomic_group
+            and any(
+                member.atomic_group == patch.atomic_group and member.id not in selected_set
+                for member in plan.patches
+            )
+        }
+    )
+    if incomplete_groups:
+        raise UsageError(
+            "Atomic patch groups must be selected in full: " + ", ".join(incomplete_groups)
+        )
     domains: dict[tuple[str, str, str], list[str]] = {}
     for patch in selected:
-        domain = "style" if patch.kind == PatchKind.COPY_STYLE else "content"
-        domains.setdefault((patch.sheet, patch.cell, domain), []).append(patch.id)
+        domains.setdefault(patch_target_key(patch), []).append(patch.id)
     conflicts = [
         f"{sheet}!{cell} ({domain}: {', '.join(sorted(patch_ids))})"
         for (sheet, cell, domain), patch_ids in sorted(domains.items())
@@ -446,6 +621,25 @@ def _select_patches(
     ]
     if conflicts:
         raise UsageError("Conflicting patches target the same cell: " + "; ".join(conflicts))
+    tails = [patch for patch in selected if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL]
+    for tail in tails:
+        cells, rows = tail_authorization(tail)
+        for patch in selected:
+            if patch.id == tail.id or patch.sheet != tail.sheet:
+                continue
+            patch_row, _ = coordinate_to_tuple(patch.cell)
+            if patch.cell in cells or patch_row in rows:
+                raise UsageError(f"Patch {patch.id} intersects formatting-tail cleanup {tail.id}")
+    whitespace_tails = [
+        patch for patch in selected if patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS
+    ]
+    for tail in whitespace_tails:
+        cells = whitespace_tail_authorization(tail)
+        for patch in selected:
+            if patch.id == tail.id or patch.sheet != tail.sheet:
+                continue
+            if patch.cell in cells:
+                raise UsageError(f"Patch {patch.id} intersects whitespace-tail cleanup {tail.id}")
     return selected
 
 
@@ -484,11 +678,61 @@ def _apply_to_parts(
         by_part.setdefault(part, []).append(patch)
     modified: dict[str, bytes] = {}
     formula_changed = False
+    styles: StylesEditor | None = None
+    if any(needs_styles(patch.kind) for patch in selected):
+        styles_name = "xl/styles.xml"
+        if styles_name not in archive.namelist():
+            raise PatchValidationError("Workbook package is missing xl/styles.xml")
+        styles = StylesEditor.from_root(parse_xml_part(archive.read(styles_name), styles_name))
     for part, patches in by_part.items():
         root = parse_xml_part(archive.read(part), part)
+        legacy_dimension_update = False
         for patch in patches:
+            if patch.kind == PatchKind.SET_COLUMN_WIDTH:
+                apply_column_width(root, patch)
+                continue
+            if patch.kind == PatchKind.SET_ROW_HEIGHT:
+                apply_row_height(root, patch)
+                continue
+            if patch.kind == PatchKind.SET_SHEET_VIEW:
+                apply_sheet_view(root, patch)
+                continue
+            if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL:
+                apply_clear_formatting_tail(archive, part, patch.sheet, root, patch)
+                continue
+            if patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS:
+                apply_remove_whitespace_tail_cells(archive, part, patch.sheet, root, patch)
+                continue
             _assert_not_in_advanced_formula_range(root, patch.cell)
-            _assert_not_in_merged_range(root, patch.cell)
+            _assert_not_in_merged_range(
+                root,
+                patch.cell,
+                allow_anchor=patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_SHRINK_TO_FIT},
+            )
+            if patch.kind == PatchKind.SET_WRAP_TEXT:
+                if styles is None:
+                    raise PatchValidationError("Styles editor was not initialized")
+                apply_alignment(root, patch, styles, shrink=False)
+                continue
+            if patch.kind == PatchKind.SET_SHRINK_TO_FIT:
+                if styles is None:
+                    raise PatchValidationError("Styles editor was not initialized")
+                apply_alignment(root, patch, styles, shrink=True)
+                continue
+            if patch.kind == PatchKind.SET_TEXT:
+                if styles is None:
+                    raise PatchValidationError("Styles editor was not initialized")
+                apply_set_text(root, patch, styles)
+                formula_changed = True
+                continue
+            if patch.kind == PatchKind.COPY_BORDER:
+                if styles is None:
+                    raise PatchValidationError("Styles editor was not initialized")
+                if patch.source_cell:
+                    _assert_not_in_advanced_formula_range(root, patch.source_cell)
+                    _assert_not_in_merged_range(root, patch.source_cell)
+                apply_copy_border(root, patch, styles)
+                continue
             target = _find_or_create_cell(root, patch.cell)
             _assert_simple_formula_cell(target, f"target {patch.sheet}!{patch.cell}")
             source_element = None
@@ -510,16 +754,21 @@ def _apply_to_parts(
                     raise PatchValidationError(f"Patch {patch.id} has a non-string formula")
                 _set_formula(target, patch.after)
                 formula_changed = True
+                legacy_dimension_update = True
             elif patch.kind == PatchKind.SET_NUMERIC:
                 _set_numeric(target, patch.after)
+                legacy_dimension_update = True
             elif patch.kind == PatchKind.COPY_STYLE:
                 if source_element is None:
                     raise PatchValidationError(f"Style patch {patch.id} has no source cell")
                 _copy_style(target, source_element)
             else:
                 raise PatchValidationError(f"Unsupported patch kind: {patch.kind}")
-        _update_dimension(root)
+        if legacy_dimension_update:
+            _update_dimension(root)
         modified[part] = _serialize_xml(root)
+    if styles is not None and styles.dirty:
+        modified["xl/styles.xml"] = _serialize_xml(styles.root)
     if formula_changed:
         modified["xl/workbook.xml"] = _mark_full_recalculation(archive.read("xl/workbook.xml"))
     return modified, formula_changed
@@ -628,6 +877,9 @@ def _validate_semantics(output: Path, selected: list[PatchOperation]) -> None:
                 raise PatchValidationError(
                     f"Patched worksheet is missing from output: {patch.sheet!r}"
                 )
+            if is_layout_kind(patch.kind):
+                validate_layout_semantics(worksheet, patch)
+                continue
             cell = worksheet[patch.cell]
             if (
                 patch.kind
@@ -641,8 +893,23 @@ def _validate_semantics(output: Path, selected: list[PatchOperation]) -> None:
                 raise PatchValidationError(f"Formula verification failed for patch {patch.id}")
             if patch.kind == PatchKind.SET_NUMERIC and cell.value != patch.after:
                 raise PatchValidationError(f"Numeric verification failed for patch {patch.id}")
-            if patch.kind == PatchKind.COPY_STYLE and cell.style_id != patch.after:
-                raise PatchValidationError(f"Style verification failed for patch {patch.id}")
+            if patch.kind == PatchKind.COPY_STYLE:
+                if not patch.source_cell:
+                    raise PatchValidationError(f"Style patch {patch.id} has no source cell")
+                try:
+                    source_row, source_column = coordinate_to_tuple(patch.source_cell)
+                except (TypeError, ValueError) as exc:
+                    raise PatchValidationError(
+                        f"Style patch {patch.id} has an invalid source cell"
+                    ) from exc
+                source_cell = worksheet._cells.get((source_row, source_column))
+                if not isinstance(cell, Cell) or not isinstance(source_cell, Cell):
+                    raise PatchValidationError(
+                        f"Style patch source is missing from output: "
+                        f"{patch.sheet}!{patch.source_cell}"
+                    )
+                if cast(Any, cell)._style != cast(Any, source_cell)._style:
+                    raise PatchValidationError(f"Style verification failed for patch {patch.id}")
     finally:
         workbook.close()
     read_only = load_workbook(output, read_only=True, data_only=False, keep_links=False)
@@ -656,6 +923,7 @@ def patch_ooxml_package(
     *,
     selected_ids: set[str] | None = None,
     safe_only: bool = False,
+    accept_layout_risk: bool = False,
     limits: PackageLimits | None = None,
     canonical_plan: PatchPlan,
 ) -> tuple[OoxmlPatchOutput, list[PatchOperation]]:
@@ -676,10 +944,21 @@ def patch_ooxml_package(
     if output.exists():
         raise UsageError(f"Output already exists and will not be overwritten: {output}")
     output.parent.mkdir(parents=True, exist_ok=True)
-    selected = _select_patches(plan, selected_ids, safe_only, enforce_safety=False)
+    selected = _select_patches(
+        plan,
+        selected_ids,
+        safe_only,
+        enforce_safety=False,
+        accept_layout_risk=accept_layout_risk,
+    )
     _verify_preconditions(source, plan, selected, limits)
     _validate_canonical_plan(plan, canonical_plan)
-    selected = _select_patches(canonical_plan, selected_ids, safe_only)
+    selected = _select_patches(
+        canonical_plan,
+        selected_ids,
+        safe_only,
+        accept_layout_risk=accept_layout_risk,
+    )
     source_hash = sha256_file(source)
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{output.stem}.", suffix=".xlsx", dir=output.parent

--- a/src/workbooklens/repair/planning.py
+++ b/src/workbooklens/repair/planning.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import Collection
 from pathlib import Path
 
 from pydantic import ValidationError
 
 from workbooklens import __version__
 from workbooklens.exceptions import UsageError
-from workbooklens.models import PatchPlan
+from workbooklens.models import PatchPlan, PatchRisk
 from workbooklens.scanner import ScanResult
 from workbooklens.utils import write_json
 
@@ -42,6 +44,89 @@ def load_patch_plan(path: Path, max_bytes: int = 10 * 1024 * 1024) -> PatchPlan:
     if len(encoded) > max_bytes:
         raise UsageError(f"Patch plan exceeds the {max_bytes}-byte limit")
     try:
-        return PatchPlan.model_validate_json(encoded)
-    except (ValidationError, UnicodeDecodeError) as exc:
-        raise UsageError(f"Patch plan does not match schema version 1: {exc}") from exc
+        payload = json.loads(encoded)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise UsageError(f"Patch plan is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != 2:
+        raise UsageError("Patch plan must use schema version 2; regenerate it with WorkbookLens")
+    try:
+        return PatchPlan.model_validate(payload)
+    except ValidationError as exc:
+        raise UsageError(f"Patch plan does not match schema version 2: {exc}") from exc
+
+
+def resolve_patch_selection(
+    plan: PatchPlan,
+    selected_ids: Collection[str] | None = None,
+    safe_only: bool = False,
+    *,
+    accept_layout_risk: bool = False,
+) -> set[str]:
+    """Resolve a fail-closed selection while preserving atomic repair groups."""
+
+    by_id = {patch.id: patch for patch in plan.patches}
+    if len(by_id) != len(plan.patches):
+        raise UsageError("Patch plan contains duplicate patch IDs")
+    requested_ids = list(selected_ids or ())
+    if len(requested_ids) != len(set(requested_ids)):
+        raise UsageError("Duplicate --patch-id selections are not allowed")
+    requested = set(requested_ids)
+    if safe_only and requested:
+        raise UsageError("--safe-only and --patch-id are mutually exclusive")
+    if safe_only and accept_layout_risk:
+        raise UsageError("--safe-only and --accept-layout-risk are mutually exclusive")
+
+    groups: dict[str, set[str]] = {}
+    for patch in plan.patches:
+        if patch.atomic_group is not None:
+            groups.setdefault(patch.atomic_group, set()).add(patch.id)
+
+    if safe_only:
+        resolved = {
+            patch.id
+            for patch in plan.patches
+            if patch.atomic_group is None and patch.safe_only_eligible
+        }
+        for member_ids in groups.values():
+            members = [by_id[patch_id] for patch_id in member_ids]
+            if all(patch.safe_only_eligible for patch in members):
+                resolved.update(member_ids)
+    else:
+        if not requested:
+            raise UsageError("Select at least one --patch-id or pass --safe-only")
+        unknown = requested - by_id.keys()
+        if unknown:
+            raise UsageError("Unknown patch IDs: " + ", ".join(sorted(unknown)))
+        resolved = set(requested)
+        for patch_id in tuple(resolved):
+            group = by_id[patch_id].atomic_group
+            if group is not None:
+                resolved.update(groups[group])
+
+        below_threshold = sorted(
+            patch_id for patch_id in resolved if float(by_id[patch_id].confidence) < 0.95
+        )
+        if below_threshold:
+            raise UsageError(
+                "WorkbookLens refuses patches below the 0.95 confidence threshold: "
+                + ", ".join(below_threshold)
+            )
+        layout_review = sorted(
+            patch_id for patch_id in resolved if by_id[patch_id].risk == PatchRisk.LAYOUT_REVIEW
+        )
+        if layout_review and not accept_layout_risk:
+            raise UsageError(
+                "Layout-review patches require explicit --accept-layout-risk: "
+                + ", ".join(layout_review)
+            )
+        unsafe = sorted(
+            patch_id
+            for patch_id in resolved
+            if not by_id[patch_id].safe and by_id[patch_id].risk != PatchRisk.LAYOUT_REVIEW
+        )
+        if unsafe:
+            raise UsageError("WorkbookLens refuses unsafe patches: " + ", ".join(unsafe))
+
+    if not resolved:
+        raise UsageError("No eligible patches were selected")
+    return resolved

--- a/src/workbooklens/reports/templates/scan.html.j2
+++ b/src/workbooklens/reports/templates/scan.html.j2
@@ -56,8 +56,10 @@
   </section>
   {% endif %}
   <section class="card" style="margin-top:16px"><h2>Sheet overview</h2>
-    <div class="table-wrap"><table><thead><tr><th>Sheet</th><th>State</th><th>Relevant cells</th><th>Used bounds</th></tr></thead><tbody>
-      {% for sheet in sheets %}<tr><td>{{ sheet.name }}</td><td>{{ sheet.state }}</td><td>{{ sheet.cells|length }}</td><td>{{ sheet.max_row }} rows × {{ sheet.max_column }} columns</td></tr>{% endfor %}
+    <div class="table-wrap"><table><thead><tr><th>Sheet</th><th>State</th><th>Relevant cells</th><th>Content range</th><th>Declared range</th><th>Saved view</th></tr></thead><tbody>
+      {% for sheet in sheets %}<tr><td>{{ sheet.name }}</td><td>{{ sheet.state }}</td><td>{{ sheet.cells|length }}</td>
+        <td><code>{{ sheet.content_dimension or '—' }}</code></td><td><code>{{ sheet.declared_dimension or '—' }}</code></td>
+        <td><code>{{ sheet.view_top_left_cell or 'A1' }}</code>{% if sheet.view_zoom_scale %} · {{ sheet.view_zoom_scale }}%{% endif %}</td></tr>{% endfor %}
     </tbody></table></div></section>
   <section class="card" style="margin-top:16px"><h2>Findings</h2>
     <div class="controls">
@@ -80,7 +82,7 @@
           {% if finding.evidence.peers %}<p><b>Peers:</b> {{ finding.evidence.peers|join(', ') }}</p>{% endif %}
           <p><b>Suggested action:</b> {{ finding.suggested_action }}</p>
           {% for patch_id in finding.patch_ids %}{% set patch = patch_map.get(patch_id) %}{% if patch %}
-          <p><b>Patch {{ patch.id }}</b> ({{ patch.kind.value }}, safe={{ patch.safe }}):
+          <p><b>Patch {{ patch.id }}</b> ({{ patch.kind.value }}, risk={{ patch.risk.value }}, safe-only={{ patch.safe_only_eligible }}):
             <code>{{ patch.before }}</code> → <code>{{ patch.after }}</code></p>{% endif %}{% endfor %}
         </details></td></tr>{% endfor %}
     </tbody></table></div>

--- a/src/workbooklens/rules/base.py
+++ b/src/workbooklens/rules/base.py
@@ -24,6 +24,7 @@ class RuleContext:
     data_regions: dict[str, list[Region]]
     formula_bands: dict[str, list[Region]]
     unsupported_formula_ranges: dict[str, tuple[CellRange, ...]] = field(default_factory=dict)
+    prior_patches: tuple[PatchOperation, ...] = field(default_factory=tuple)
 
 
 @dataclass(slots=True)

--- a/src/workbooklens/rules/builtin.py
+++ b/src/workbooklens/rules/builtin.py
@@ -1,4 +1,4 @@
-"""The fifteen deterministic WorkbookLens built-in rules."""
+"""The deterministic WorkbookLens built-in rules."""
 
 from __future__ import annotations
 
@@ -13,12 +13,17 @@ from itertools import pairwise
 from typing import Any, cast
 
 from openpyxl.cell.cell import Cell, MergedCell
+from openpyxl.formula import Tokenizer
+from openpyxl.formula.tokenizer import TokenizerError
 from openpyxl.utils.cell import (
+    column_index_from_string,
+    coordinate_to_tuple,
     get_column_letter,
     range_boundaries,
 )
 from openpyxl.worksheet.cell_range import CellRange
 from openpyxl.worksheet.worksheet import Worksheet
+from openpyxl.xml.constants import MAX_COLUMN, MAX_ROW
 
 from workbooklens.formulas import (
     UnsupportedFormulaError,
@@ -26,13 +31,34 @@ from workbooklens.formulas import (
     normalize_formula,
     translate_formula,
 )
+from workbooklens.layout import (
+    FormattingTail,
+    WhitespaceTail,
+    column_layout_fingerprint,
+    column_width,
+    estimated_text_width,
+    explicit_row_height,
+    find_formatting_tail,
+    find_whitespace_tail,
+    has_visible_border,
+    measure_text_cell,
+    range_intersects,
+    row_height,
+    row_layout_fingerprint,
+    sheet_view_fingerprint,
+    tail_layout_fingerprint,
+    visual_border_signature,
+    whitespace_tail_layout_fingerprint,
+)
 from workbooklens.models import (
+    LAYOUT_REVIEW_PATCH_KINDS,
     Confidence,
     Evidence,
     Finding,
     PatchKind,
     PatchOperation,
     PatchPrecondition,
+    PatchRisk,
     Region,
     Severity,
 )
@@ -42,6 +68,10 @@ from workbooklens.utils import stable_id
 from workbooklens.worksheet_state import hidden_column_spans, is_column_hidden
 
 EXCEL_ERRORS = {"#NULL!", "#DIV/0!", "#VALUE!", "#REF!", "#NAME?", "#NUM!", "#N/A"}
+CONSERVATIVE_VIEWPORT_WIDTH = 110.0
+CONSERVATIVE_VIEWPORT_HEIGHT = 360.0
+MIN_AUTOMATIC_VIEW_ZOOM = 50
+MAX_EXCEL_ROW_HEIGHT = 409.5
 SIMPLE_SUM_RE = re.compile(
     r"^=SUM\((?P<sheet>(?:'(?:[^']|'')+'|[^'!]+)!)?"
     r"(?P<col1>\$?[A-Z]{1,3})(?P<start>\$?\d+):"
@@ -211,7 +241,7 @@ def _make_finding(
         evidence=evidence,
         expected=expected,
         suggested_action=suggested_action,
-        safe_patch_available=any(patch.safe for patch in patches),
+        safe_patch_available=any(patch.safe_only_eligible for patch in patches),
         patch_ids=[patch.id for patch in patches],
     )
 
@@ -226,8 +256,11 @@ def _make_patch(
     confidence: float,
     description: str,
     source_cell: str | None = None,
+    layout_fingerprint: str | None = None,
+    atomic_group: str | None = None,
 ) -> PatchOperation:
-    safe = confidence >= 0.95
+    risk = PatchRisk.LAYOUT_REVIEW if kind in LAYOUT_REVIEW_PATCH_KINDS else PatchRisk.SAFE
+    safe = confidence >= 0.95 and risk == PatchRisk.SAFE
     expected_formula = cell.value if cell.data_type == "f" and isinstance(cell.value, str) else None
     patch_id = stable_id(
         "patch", kind.value, worksheet.title, cell.coordinate, before, after, source_cell
@@ -242,13 +275,16 @@ def _make_patch(
         source_cell=source_cell,
         confidence=_confidence(confidence),
         safe=safe,
+        risk=risk,
         description=description,
         precondition=PatchPrecondition(
             cell_fingerprint=cell_fingerprint(cell),
             expected_value=None if cell.data_type == "f" else cell.value,
             expected_formula=expected_formula,
             expected_style_id=cell.style_id,
+            layout_fingerprint=layout_fingerprint,
         ),
+        atomic_group=atomic_group,
     )
 
 
@@ -307,6 +343,71 @@ def _is_aggregate_formula(value: Any) -> bool:
             output.append(" " if inside_string else character)
         index += 1
     return AGGREGATE_FUNCTION_RE.search("".join(output)) is not None
+
+
+def _aggregate_formula_spans_other_rows(value: Any, row: int) -> bool:
+    if not _is_aggregate_formula(value):
+        return False
+    try:
+        tokens = Tokenizer(cast(str, value)).items
+    except (ValueError, IndexError, TokenizerError):
+        return True
+
+    function_stack: list[bool] = []
+    aggregate_depth = 0
+    references: list[str] = []
+    for token in tokens:
+        if token.type == "FUNC" and token.subtype == "OPEN":
+            is_aggregate = AGGREGATE_FUNCTION_RE.search(token.value) is not None
+            function_stack.append(is_aggregate)
+            aggregate_depth += int(is_aggregate)
+        elif token.type == "FUNC" and token.subtype == "CLOSE":
+            if not function_stack:
+                return True
+            aggregate_depth -= int(function_stack.pop())
+        elif aggregate_depth and token.type == "OPERAND" and token.subtype == "RANGE":
+            references.append(token.value)
+    if function_stack:
+        return True
+
+    parsed_reference = False
+    for reference in references:
+        local_reference = reference.rsplit("!", 1)[-1].replace("$", "")
+        try:
+            _min_column, min_row, _max_column, max_row = range_boundaries(local_reference)
+        except ValueError:
+            if "@" in reference:
+                parsed_reference = True
+                continue
+            return True
+        parsed_reference = True
+        if min_row is None or max_row is None or min_row != row or max_row != row:
+            return True
+    return False if parsed_reference else bool(references)
+
+
+def _finite_nonnegative_pane_split(value: Any) -> float | None:
+    if value is None:
+        return 0.0
+    if isinstance(value, bool):
+        return None
+    try:
+        split = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return split if math.isfinite(split) and split >= 0 else None
+
+
+def _bounded_view_coordinate(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        row, column = coordinate_to_tuple(value.replace("$", ""))
+    except (TypeError, ValueError):
+        return None
+    if not 1 <= row <= MAX_ROW or not 1 <= column <= MAX_COLUMN:
+        return None
+    return row, column
 
 
 def _is_band_boundary(cell: Cell, band: Region) -> bool:
@@ -447,20 +548,647 @@ def _style_copy_preserves_semantics(target: Cell, source: Cell) -> bool:
     )
 
 
-def _visual_style_key(cell: Cell) -> tuple[Any, ...]:
-    """Group visually equivalent cells without treating protection flags as decoration."""
+def _intersects_any(cell_ranges: Sequence[str], target: str) -> bool:
+    try:
+        return any(range_intersects(cell_range, target) for cell_range in cell_ranges)
+    except ValueError:
+        return False
+
+
+def _unqualified_ranges(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    candidates: Iterable[Any]
+    ranges = getattr(value, "ranges", None)
+    if ranges is not None:
+        candidates = ranges
+    elif isinstance(value, (list, tuple, set)):
+        candidates = value
+    else:
+        candidates = str(value).split(",")
+    normalized: list[str] = []
+    for candidate in candidates:
+        text = str(candidate).strip()
+        if not text:
+            continue
+        if "!" in text:
+            text = text.rsplit("!", 1)[1]
+        text = text.replace("$", "").strip().strip("'")
+        row_match = re.fullmatch(r"(\d+):(\d+)", text)
+        column_match = re.fullmatch(r"([A-Z]+):([A-Z]+)", text, re.IGNORECASE)
+        if row_match:
+            text = f"A{row_match.group(1)}:XFD{row_match.group(2)}"
+        elif column_match:
+            text = f"{column_match.group(1)}1:{column_match.group(2)}1048576"
+        if text:
+            normalized.append(text)
+    return tuple(normalized)
+
+
+def _drawing_anchor_range(drawing: Any) -> str | None:
+    anchor = getattr(drawing, "anchor", None)
+    if isinstance(anchor, str):
+        return anchor
+    start = getattr(anchor, "_from", None)
+    if start is None:
+        return None
+    end = getattr(anchor, "to", None)
+    min_row = int(start.row) + 1
+    min_column = int(start.col) + 1
+    max_row = int(end.row) + 1 if end is not None else min_row
+    max_column = int(end.col) + 1 if end is not None else min_column
+    left = f"{get_column_letter(min_column)}{min_row}"
+    right = f"{get_column_letter(max_column)}{max_row}"
+    return left if left == right else f"{left}:{right}"
+
+
+def _tail_intersects_structure(
+    worksheet: Worksheet,
+    tail: FormattingTail | WhitespaceTail,
+) -> bool:
+    cell_ranges = tail.cell_ranges
+    row_ranges = tuple(
+        f"A{start_text}:XFD{end_text if separator else start_text}"
+        for range_text in tail.row_ranges
+        for start_text, separator, end_text in [range_text.partition(":")]
+    )
+    target_ranges = (*cell_ranges, *row_ranges)
+    for cell_range in target_ranges:
+        if any(
+            range_intersects(cell_range, str(merged)) for merged in worksheet.merged_cells.ranges
+        ):
+            return True
+        if any(range_intersects(cell_range, table.ref) for table in worksheet.tables.values()):
+            return True
+        if worksheet.auto_filter.ref and range_intersects(cell_range, worksheet.auto_filter.ref):
+            return True
+        if worksheet.data_validations is not None:
+            for validation in worksheet.data_validations.dataValidation:
+                if any(
+                    range_intersects(cell_range, str(validation_range))
+                    for validation_range in validation.ranges.ranges
+                ):
+                    return True
+        for conditional_formatting in worksheet.conditional_formatting:
+            if any(
+                range_intersects(cell_range, str(target))
+                for target in conditional_formatting.sqref.ranges
+            ):
+                return True
+    if any(
+        _intersects_any(target_ranges, print_range)
+        for print_range in _unqualified_ranges(
+            (worksheet.print_area, worksheet.print_title_rows, worksheet.print_title_cols)
+        )
+    ):
+        return True
+    workbook = worksheet.parent
+    if workbook is not None:
+        for defined_name in workbook.defined_names.values():
+            try:
+                destinations = list(defined_name.destinations)
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if any(
+                sheet_name == worksheet.title
+                and any(
+                    _intersects_any(target_ranges, normalized)
+                    for normalized in _unqualified_ranges(range_text)
+                )
+                for sheet_name, range_text in destinations
+            ):
+                return True
+    for coordinate in tail.cell_coordinates:
+        row, column = coordinate_to_tuple(coordinate)
+        cell = worksheet._cells.get((row, column))
+        if isinstance(cell, Cell) and (cell.comment is not None or cell.hyperlink is not None):
+            return True
+    if any(
+        any(
+            CellRange(cell_range).min_row <= item.id <= CellRange(cell_range).max_row
+            for cell_range in target_ranges
+        )
+        for item in worksheet.row_breaks.brk
+    ):
+        return True
+    if any(
+        any(
+            CellRange(cell_range).min_col <= item.id <= CellRange(cell_range).max_col
+            for cell_range in target_ranges
+        )
+        for item in worksheet.col_breaks.brk
+    ):
+        return True
+    for drawing in (
+        *getattr(worksheet, "_charts", ()),
+        *getattr(worksheet, "_images", ()),
+    ):
+        anchor_range = _drawing_anchor_range(drawing)
+        if anchor_range is not None and _intersects_any(target_ranges, anchor_range):
+            return True
+    return False
+
+
+def _formula_reference_target(
+    reference: str,
+    *,
+    current_sheet: str,
+    target_sheet: str,
+) -> tuple[bool, str] | None:
+    if "[" in reference or "]" in reference:
+        return False, reference
+    if "!" not in reference:
+        return current_sheet.casefold() == target_sheet.casefold(), reference
+    qualifier, body = reference.rsplit("!", 1)
+    qualifier = qualifier.strip()
+    if qualifier.startswith("'") and qualifier.endswith("'"):
+        qualifier = qualifier[1:-1].replace("''", "'")
+    if ":" in qualifier:
+        return None
+    return qualifier.casefold() == target_sheet.casefold(), body
+
+
+def _tail_has_formula_blocker(
+    context: RuleContext,
+    worksheet: Worksheet,
+    tail: WhitespaceTail,
+) -> bool:
+    targets = tail.cell_ranges
+    for candidate_sheet in context.workbook.worksheets:
+        for cell in candidate_sheet._cells.values():
+            if (
+                not isinstance(cell, Cell)
+                or cell.data_type != "f"
+                or not isinstance(cell.value, str)
+            ):
+                continue
+            features = analyze_formula(cell.value)
+            if features.unsupported_reason is not None or any(
+                name in {"INDIRECT", "OFFSET"} for name in features.volatile_functions
+            ):
+                return True
+            for reference in features.references:
+                target = _formula_reference_target(
+                    reference,
+                    current_sheet=candidate_sheet.title,
+                    target_sheet=worksheet.title,
+                )
+                if target is None:
+                    return True
+                targets_sheet, body = target
+                if not targets_sheet:
+                    continue
+                try:
+                    if any(range_intersects(body, cell_range) for cell_range in targets):
+                        return True
+                except ValueError:
+                    return True
+    return False
+
+
+def _visible_text_cells(worksheet: Worksheet) -> list[Cell]:
+    return sorted(
+        (
+            cell
+            for cell in worksheet._cells.values()
+            if isinstance(cell, Cell)
+            and isinstance(cell.value, str)
+            and cell.value.strip()
+            and not _is_hidden_cell(worksheet, cell)
+        ),
+        key=lambda cell: (cell.row, cell.column),
+    )
+
+
+def _merged_range(worksheet: Worksheet, cell: Cell) -> CellRange | None:
+    return next(
+        (merged for merged in worksheet.merged_cells.ranges if cell.coordinate in merged),
+        None,
+    )
+
+
+def _vertical_shared_edge_has_style(
+    worksheet: Worksheet,
+    row: int,
+    left_column: int,
+) -> bool:
+    """Return whether the boundary between two columns has a visible side."""
+
+    if not 1 <= left_column < 16_384:
+        return False
+    left = worksheet._cells.get((row, left_column))
+    right = worksheet._cells.get((row, left_column + 1))
+    left_side = left.border.right if isinstance(left, Cell) else None
+    right_side = right.border.left if isinstance(right, Cell) else None
+    return bool(
+        (left_side is not None and left_side.style is not None)
+        or (right_side is not None and right_side.style is not None)
+    )
+
+
+def _overflow_is_visually_blocked(
+    worksheet: Worksheet,
+    cell: Cell,
+    required_width: float,
+    available_width: float,
+) -> bool:
+    """Return whether an unwrapped string cannot use natural blank-cell overflow."""
+
+    merged = _merged_range(worksheet, cell)
+    if merged is not None:
+        return required_width > available_width
+    min_column = merged.min_col if merged is not None else cell.column
+    max_column = merged.max_col if merged is not None else cell.column
+    alignment = (cell.alignment.horizontal or "general").lower()
+    directions: tuple[tuple[int, int], ...]
+    if alignment == "right":
+        directions = ((-1, min_column - 1),)
+    elif alignment in {"center", "centercontinuous", "distributed"}:
+        directions = ((-1, min_column - 1), (1, max_column + 1))
+    else:
+        directions = ((1, max_column + 1),)
+    extra_width = max(0.0, required_width - available_width)
+    for step, start_column in directions:
+        remaining = extra_width
+        column = start_column
+        while remaining > 0 and 1 <= column <= 16_384:
+            left_column = column - 1 if step > 0 else column
+            if _vertical_shared_edge_has_style(worksheet, cell.row, left_column):
+                return True
+            neighbor = worksheet._cells.get((cell.row, column))
+            if isinstance(neighbor, Cell) and neighbor.value is not None:
+                return True
+            if not is_column_hidden(worksheet, column):
+                remaining -= column_width(worksheet, column)
+            column += step
+        if remaining > 0:
+            return True
+    return False
+
+
+def _actual_border_source(
+    worksheet: Worksheet,
+    cell: Cell,
+    edge: str,
+) -> tuple[str, str] | None:
+    side = getattr(cell.border, edge)
+    if side is not None and side.style is not None:
+        return cell.coordinate, edge
+    peer_row = cell.row
+    peer_column = cell.column
+    opposite = edge
+    if edge == "left":
+        peer_column -= 1
+        opposite = "right"
+    elif edge == "right":
+        peer_column += 1
+        opposite = "left"
+    elif edge == "top":
+        peer_row -= 1
+        opposite = "bottom"
+    else:
+        peer_row += 1
+        opposite = "top"
+    peer = worksheet._cells.get((peer_row, peer_column))
+    if isinstance(peer, Cell):
+        peer_side = getattr(peer.border, opposite)
+        if peer_side is not None and peer_side.style is not None:
+            return peer.coordinate, opposite
+    return None
+
+
+def _shared_edge_key(cell: Cell, edge: str) -> tuple[str, int, int]:
+    if edge == "left":
+        return "vertical", cell.row, cell.column - 1
+    if edge == "right":
+        return "vertical", cell.row, cell.column
+    if edge == "top":
+        return "horizontal", cell.row - 1, cell.column
+    return "horizontal", cell.row, cell.column
+
+
+def _shared_edge_has_materialized_peer(
+    worksheet: Worksheet,
+    cell: Cell,
+    edge: str,
+) -> bool:
+    row = cell.row
+    column = cell.column
+    if edge == "left":
+        column -= 1
+    elif edge == "right":
+        column += 1
+    elif edge == "top":
+        row -= 1
+    else:
+        row += 1
+    if row < 1 or not 1 <= column <= 16_384:
+        return False
+    peer = worksheet._cells.get((row, column))
+    return bool(
+        isinstance(peer, Cell)
+        and (
+            (
+                peer.value is not None
+                and not (isinstance(peer.value, str) and not peer.value.strip())
+            )
+            or peer.has_style
+        )
+        and not _is_hidden_cell(worksheet, peer)
+        and not _is_in_merged_range(worksheet, peer.coordinate)
+    )
+
+
+def _parallel_border_source(
+    worksheet: Worksheet,
+    cell: Cell,
+    edge: str,
+    region: Region,
+) -> tuple[str, str, tuple[Any, ...], float, int, int] | None:
+    """Find a parallel grid-edge consensus, retaining low-confidence evidence."""
+
+    edge_index = ("left", "right", "top", "bottom").index(edge)
+    candidates: list[tuple[str, str, tuple[Any, ...]] | None] = []
+    positions = (
+        ((row, cell.column) for row in range(region.min_row, region.max_row + 1))
+        if edge in {"left", "right"}
+        else ((cell.row, column) for column in range(region.min_column, region.max_column + 1))
+    )
+    for row, column in positions:
+        if row == cell.row and column == cell.column:
+            continue
+        peer = worksheet._cells.get((row, column))
+        if (
+            not isinstance(peer, Cell)
+            or not _is_materialized_table_cell(peer)
+            or _is_hidden_cell(worksheet, peer)
+            or _is_in_merged_range(worksheet, peer.coordinate)
+        ):
+            continue
+        source = _actual_border_source(worksheet, peer, edge)
+        signature = visual_border_signature(worksheet, peer)[edge_index]
+        if source is not None and signature[0] is not None:
+            candidates.append((source[0], source[1], signature))
+        else:
+            candidates.append(None)
+    if len(candidates) < 2:
+        return None
+    visible_candidates = [candidate for candidate in candidates if candidate is not None]
+    if not visible_candidates:
+        return None
+    signature, count = Counter(item[2] for item in visible_candidates).most_common(1)[0]
+    confidence = count / len(candidates)
+    if count < 2 or confidence < 0.75:
+        return None
+    source_cell, source_edge, _ = next(item for item in visible_candidates if item[2] == signature)
+    return source_cell, source_edge, signature, confidence, count, len(candidates)
+
+
+def _edge_is_internal_to_region(cell: Cell, edge: str, region: Region) -> bool:
+    if edge == "left":
+        return cell.column > region.min_column
+    if edge == "right":
+        return cell.column < region.max_column
+    if edge == "top":
+        return cell.row > region.min_row
+    return cell.row < region.max_row
+
+
+def _is_materialized_table_cell(cell: Cell) -> bool:
+    return bool(
+        (cell.value is not None and not (isinstance(cell.value, str) and not cell.value.strip()))
+        or cell.has_style
+    )
+
+
+def _dense_rectangular_border_region(
+    worksheet: Worksheet,
+    region: Region,
+) -> Region | None:
+    """Trim ragged margins, then require a sizeable rectangle with a dominant grid."""
+
+    def structured_at(row: int, column: int) -> bool:
+        cell = worksheet._cells.get((row, column))
+        return bool(
+            isinstance(cell, Cell)
+            and _is_materialized_table_cell(cell)
+            and not _is_hidden_cell(worksheet, cell)
+            and not _is_in_merged_range(worksheet, cell.coordinate)
+        )
+
+    min_row = region.min_row
+    max_row = region.max_row
+    min_column = region.min_column
+    max_column = region.max_column
+    while min_row <= max_row and min_column <= max_column:
+        height = max_row - min_row + 1
+        width = max_column - min_column + 1
+        if height < 3 or width < 3:
+            return None
+        row_coverages = {
+            row: sum(structured_at(row, column) for column in range(min_column, max_column + 1))
+            / width
+            for row in (min_row, max_row)
+        }
+        column_coverages = {
+            column: sum(structured_at(row, column) for row in range(min_row, max_row + 1)) / height
+            for column in (min_column, max_column)
+        }
+        if row_coverages[min_row] < 0.75:
+            min_row += 1
+            continue
+        if row_coverages[max_row] < 0.75:
+            max_row -= 1
+            continue
+        if column_coverages[min_column] < 0.75:
+            min_column += 1
+            continue
+        if column_coverages[max_column] < 0.75:
+            max_column -= 1
+            continue
+        break
+    height = max_row - min_row + 1
+    width = max_column - min_column + 1
+    area = height * width
+    if height < 3 or width < 3 or area < 12:
+        return None
+    structured = 0
+    bordered = 0
+    for row in range(min_row, max_row + 1):
+        for column in range(min_column, max_column + 1):
+            if not structured_at(row, column):
+                continue
+            structured += 1
+            cell = worksheet._cells.get((row, column))
+            bordered += int(isinstance(cell, Cell) and has_visible_border(cell))
+    density = structured / area
+    if density < 0.75 or bordered / area < 0.60:
+        return None
+    return Region(
+        sheet=region.sheet,
+        min_row=min_row,
+        max_row=max_row,
+        min_column=min_column,
+        max_column=max_column,
+        kind=region.kind,
+        confidence=Confidence(min(float(region.confidence), density)),
+    )
+
+
+def _visible_layout_bounds(
+    worksheet: Worksheet,
+    *,
+    excluded_coordinates: set[str] | None = None,
+) -> tuple[int, int, int, int] | None:
+    """Return bounds of visible values, borders, fills, merges, and sheet structures."""
+
+    excluded = excluded_coordinates or set()
+    row_bounds: list[int] = []
+    column_bounds: list[int] = []
+
+    def extend(cell_range: CellRange) -> None:
+        row_bounds.extend((cell_range.min_row, cell_range.max_row))
+        column_bounds.extend((cell_range.min_col, cell_range.max_col))
+
+    for cell in worksheet._cells.values():
+        if (
+            not isinstance(cell, Cell)
+            or cell.coordinate in excluded
+            or _is_hidden_cell(worksheet, cell)
+        ):
+            continue
+        visible_value = cell.value is not None and not (
+            isinstance(cell.value, str) and not cell.value.strip()
+        )
+        visible_format = has_visible_border(cell) or cell.fill.fill_type not in {None, "none"}
+        if (
+            visible_value
+            or visible_format
+            or cell.comment is not None
+            or cell.hyperlink is not None
+        ):
+            row_bounds.append(cell.row)
+            column_bounds.append(cell.column)
+    for merged in worksheet.merged_cells.ranges:
+        extend(CellRange(str(merged)))
+    for table in worksheet.tables.values():
+        extend(CellRange(table.ref))
+    if worksheet.auto_filter.ref:
+        extend(CellRange(worksheet.auto_filter.ref))
+    if worksheet.data_validations is not None:
+        for validation in worksheet.data_validations.dataValidation:
+            for target in validation.ranges.ranges:
+                extend(CellRange(str(target)))
+    for conditional_formatting in worksheet.conditional_formatting:
+        for target in conditional_formatting.sqref.ranges:
+            extend(CellRange(str(target)))
+    if not row_bounds or not column_bounds:
+        return None
+    return min(row_bounds), min(column_bounds), max(row_bounds), max(column_bounds)
+
+
+def _predicted_layout_size(
+    context: RuleContext,
+    worksheet: Worksheet,
+    visible_columns: Sequence[int],
+    visible_rows: Sequence[int],
+) -> tuple[float, float, int, int]:
+    """Estimate layout size after earlier reviewed width and height proposals."""
+
+    widths = {column: column_width(worksheet, column) for column in visible_columns}
+    heights = {row: row_height(worksheet, row) for row in visible_rows}
+    width_updates = 0
+    height_updates = 0
+    for patch in context.prior_patches:
+        if patch.sheet != worksheet.title or not isinstance(patch.after, dict):
+            continue
+        if patch.kind == PatchKind.SET_COLUMN_WIDTH:
+            column_value = patch.after.get("column")
+            width_value = patch.after.get("width")
+            if (
+                isinstance(column_value, str)
+                and not isinstance(width_value, bool)
+                and isinstance(width_value, (int, float))
+            ):
+                try:
+                    column = column_index_from_string(column_value)
+                except ValueError:
+                    continue
+                if column in widths and float(width_value) > widths[column]:
+                    widths[column] = float(width_value)
+                    width_updates += 1
+        elif patch.kind == PatchKind.SET_ROW_HEIGHT:
+            row_value = patch.after.get("row")
+            height_value = patch.after.get("height")
+            if (
+                isinstance(row_value, int)
+                and not isinstance(row_value, bool)
+                and not isinstance(height_value, bool)
+                and isinstance(height_value, (int, float))
+                and row_value in heights
+                and float(height_value) > heights[row_value]
+            ):
+                heights[row_value] = float(height_value)
+                height_updates += 1
+    return sum(widths.values()), sum(heights.values()), width_updates, height_updates
+
+
+def _nearest_header(worksheet: Worksheet, cell: Cell) -> Cell | None:
+    for row in range(cell.row - 1, max(0, cell.row - 9), -1):
+        header = worksheet._cells.get((row, cell.column))
+        if isinstance(header, Cell) and isinstance(header.value, str) and header.value.strip():
+            return header
+    return None
+
+
+def _integer_identifier_text(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value) if value >= 0 else None
+    if isinstance(value, float) and math.isfinite(value) and value >= 0 and value.is_integer():
+        return format(value, ".0f")
+    return None
+
+
+def _sheet_snapshot(context: RuleContext, worksheet: Worksheet) -> Any | None:
+    return next(
+        (sheet for sheet in context.snapshot.sheets if sheet.name == worksheet.title),
+        None,
+    )
+
+
+def _visual_style_key(worksheet: Worksheet, cell: Cell) -> tuple[Any, ...]:
+    """Group visually equivalent cells without treating storage details as decoration."""
+
+    border = cell.border
+    non_cardinal_border = (
+        copy(border.start),
+        copy(border.end),
+        copy(border.diagonal),
+        copy(border.vertical),
+        copy(border.horizontal),
+        border.outline,
+        border.diagonalUp,
+        border.diagonalDown,
+    )
 
     return (
         copy(cell.font),
         copy(cell.fill),
-        copy(cell.border),
+        visual_border_signature(worksheet, cell),
+        non_cardinal_border,
         copy(cell.alignment),
         cell.number_format,
     )
 
 
 def _row_has_summary_semantics(
-    worksheet: Worksheet, row: int, region: Region | None = None
+    worksheet: Worksheet,
+    row: int,
+    region: Region | None = None,
+    *,
+    include_overrides: bool = True,
 ) -> bool:
     cells = (
         (
@@ -474,9 +1202,15 @@ def _row_has_summary_semantics(
     )
     for cell in cells:
         value = cell.value
-        if _is_aggregate_formula(value):
+        if _aggregate_formula_spans_other_rows(value, row):
             return True
-        if isinstance(value, str) and SUMMARY_LABEL_RE.search(value.strip()):
+        if not isinstance(value, str) or not SUMMARY_LABEL_RE.search(value.strip()):
+            continue
+        normalized = unicodedata.normalize("NFKC", value).casefold()
+        is_override = any(
+            marker in normalized for marker in ("adjustment", "override", "调整", "覆盖")
+        )
+        if include_overrides or not is_override:
             return True
     return False
 
@@ -634,9 +1368,13 @@ def _row_visual_style_matches_peer_consensus(
         )[:8]
         if len(peers) < 3:
             continue
-        counts = Counter(_visual_style_key(peer) for peer in peers)
+        counts = Counter(_visual_style_key(worksheet, peer) for peer in peers)
         consensus, count = counts.most_common(1)[0]
-        if count >= 3 and count / len(peers) >= 0.75 and _visual_style_key(row_cell) != consensus:
+        if (
+            count >= 3
+            and count / len(peers) >= 0.75
+            and _visual_style_key(worksheet, row_cell) != consensus
+        ):
             return False
     return True
 
@@ -1058,7 +1796,8 @@ class SuspiciousSumBoundaryRule(WorkbookRule):
                 candidate = _cell(worksheet, candidate_row, cell.column)
                 if isinstance(candidate.value, bool):
                     continue
-                if worksheet.row_dimensions[candidate_row].hidden:
+                candidate_dimension = worksheet.row_dimensions.get(candidate_row)
+                if candidate_dimension is not None and candidate_dimension.hidden:
                     continue
                 if any(candidate.coordinate in merged for merged in worksheet.merged_cells.ranges):
                     continue
@@ -1294,15 +2033,22 @@ class StyleOutlierRule(WorkbookRule):
         seen: set[tuple[str, str]] = set()
         for worksheet in context.workbook.worksheets:
             for region in context.data_regions[worksheet.title]:
+                detail_rows = [
+                    row
+                    for row in range(region.min_row + 1, region.max_row + 1)
+                    if not _row_has_summary_semantics(worksheet, row, include_overrides=False)
+                ]
                 for column in range(region.min_column, region.max_column + 1):
                     cells = [
                         _cell(worksheet, row, column)
-                        for row in range(region.min_row + 1, region.max_row + 1)
+                        for row in detail_rows
                         if _cell(worksheet, row, column).value is not None
                     ]
                     if len(cells) < 5:
                         continue
-                    style_by_cell = {cell.coordinate: _visual_style_key(cell) for cell in cells}
+                    style_by_cell = {
+                        cell.coordinate: _visual_style_key(worksheet, cell) for cell in cells
+                    }
                     counts = Counter(style_by_cell.values())
                     consensus_style, count = counts.most_common(1)[0]
                     ratio = count / len(cells)
@@ -1890,6 +2636,1019 @@ class InconsistentDataValidationRule(WorkbookRule):
         return result
 
 
+class TextDisplayRiskRule(WorkbookRule):
+    rule_id = "WL016_TEXT_DISPLAY_RISK"
+    title = "Text may be clipped or cross a visible boundary"
+
+    def run(self, context: RuleContext) -> RuleResult:
+        result = RuleResult()
+        for worksheet in context.workbook.worksheets:
+            issues_by_row: dict[int, list[tuple[Cell, Any, str]]] = defaultdict(list)
+            for cell in _visible_text_cells(worksheet):
+                measurement = measure_text_cell(worksheet, cell)
+                if measurement is None:
+                    continue
+                wrap_text = bool(cell.alignment.wrap_text)
+                explicit_height = explicit_row_height(worksheet, cell.row)
+                height_limit = explicit_height
+                if height_limit is None and measurement.merged_range is not None:
+                    height_limit = measurement.current_height
+                forced_multiline = "\n" in cast(str, cell.value) or "\r" in cast(str, cell.value)
+                if (
+                    (wrap_text or forced_multiline)
+                    and height_limit is not None
+                    and measurement.required_lines >= 2
+                    and measurement.required_height > height_limit + 2.0
+                ):
+                    issues_by_row[cell.row].append((cell, measurement, "vertical"))
+                    continue
+                if (
+                    not wrap_text
+                    and not forced_multiline
+                    and measurement.width_ratio >= 1.10
+                    and _overflow_is_visually_blocked(
+                        worksheet,
+                        cell,
+                        measurement.required_width,
+                        measurement.available_width,
+                    )
+                ):
+                    wrapped_measurement = measure_text_cell(
+                        worksheet,
+                        cell,
+                        assume_wrap=True,
+                    )
+                    if wrapped_measurement is not None:
+                        issues_by_row[cell.row].append((cell, wrapped_measurement, "horizontal"))
+            horizontal_by_column: dict[int, list[tuple[Cell, Any, str]]] = defaultdict(list)
+            for issues in issues_by_row.values():
+                for issue in issues:
+                    if issue[2] == "horizontal" and issue[1].merged_range is None:
+                        horizontal_by_column[issue[0].column].append(issue)
+            width_columns = {
+                column for column, issues in horizontal_by_column.items() if len(issues) >= 3
+            }
+            width_patches: dict[int, PatchOperation] = {}
+            if not _is_protected_target(worksheet):
+                for column in sorted(width_columns):
+                    column_issues = sorted(
+                        horizontal_by_column[column],
+                        key=lambda issue: (issue[0].row, issue[0].column),
+                    )
+                    current_width = column_width(worksheet, column)
+                    measured_width = max(issue[1].required_width for issue in column_issues)
+                    minimum_clear_width = measured_width
+                    if minimum_clear_width > 40.0:
+                        continue
+                    target_width = max(
+                        math.ceil(minimum_clear_width * 4.0) / 4.0,
+                        math.ceil((current_width + 0.5) * 4.0) / 4.0,
+                    )
+                    if target_width <= column_width(worksheet, column) + 0.25:
+                        continue
+                    anchor = column_issues[0][0]
+                    width_patch = _make_patch(
+                        kind=PatchKind.SET_COLUMN_WIDTH,
+                        worksheet=worksheet,
+                        cell=anchor,
+                        before={
+                            "column": get_column_letter(column),
+                            "width": current_width,
+                        },
+                        after={
+                            "column": get_column_letter(column),
+                            "width": target_width,
+                        },
+                        confidence=0.96,
+                        description=(
+                            "Widen the repeatedly overflowing text column to the measured local maximum."
+                        ),
+                        layout_fingerprint=column_layout_fingerprint(worksheet, column),
+                    )
+                    result.patches.append(width_patch)
+                    width_patches[column] = width_patch
+            for row, issues in sorted(issues_by_row.items()):
+                height_issues = [
+                    issue
+                    for issue in issues
+                    if not (issue[2] == "horizontal" and issue[0].column in width_patches)
+                ]
+                horizontal_issues = [issue for issue in height_issues if issue[2] == "horizontal"]
+                # Every remaining horizontal issue will receive wrap_text. Its wrapped
+                # height must participate in the same atomic row-height plan, even when
+                # this row already contains a separate vertical clipping issue.
+                height_basis = height_issues
+                atomic_group = (
+                    stable_id("atomic", self.rule_id, worksheet.title, row)
+                    if horizontal_issues
+                    else None
+                )
+                required_height = max(
+                    (issue[1].required_height for issue in height_basis),
+                    default=row_height(worksheet, row),
+                )
+                proposed_height = math.ceil(required_height * 2.0) / 2.0
+                current_height = explicit_row_height(worksheet, row)
+                effective_height = row_height(worksheet, row)
+                anchor = (
+                    max(
+                        height_issues,
+                        key=lambda issue: (issue[1].required_height, -issue[0].column),
+                    )[0]
+                    if height_issues
+                    else issues[0][0]
+                )
+                row_patch: PatchOperation | None = None
+                if (
+                    height_issues
+                    and not _is_protected_target(worksheet)
+                    and proposed_height <= MAX_EXCEL_ROW_HEIGHT
+                    and proposed_height > effective_height + 0.5
+                ):
+                    row_patch = _make_patch(
+                        kind=PatchKind.SET_ROW_HEIGHT,
+                        worksheet=worksheet,
+                        cell=anchor,
+                        before={
+                            "row": row,
+                            "height": current_height,
+                            "effective_height": effective_height,
+                        },
+                        after={"row": row, "height": proposed_height},
+                        confidence=0.96,
+                        description=(
+                            f"Increase row {row} height to {proposed_height:g} points after review."
+                        ),
+                        layout_fingerprint=row_layout_fingerprint(worksheet, row),
+                        atomic_group=atomic_group,
+                    )
+                    result.patches.append(row_patch)
+                for cell, measurement, issue_kind in issues:
+                    patches: list[PatchOperation] = []
+                    shared_width_patch = width_patches.get(cell.column)
+                    if issue_kind == "horizontal" and shared_width_patch is not None:
+                        patches.append(shared_width_patch)
+                    elif (
+                        issue_kind == "horizontal"
+                        and not _is_protected_target(worksheet)
+                        and (
+                            row_patch is not None
+                            or measurement.required_height <= effective_height + 0.5
+                        )
+                    ):
+                        wrap_patch = _make_patch(
+                            kind=PatchKind.SET_WRAP_TEXT,
+                            worksheet=worksheet,
+                            cell=cell,
+                            before={"wrap_text": bool(cell.alignment.wrap_text)},
+                            after={"wrap_text": True},
+                            confidence=0.96,
+                            description="Wrap the blocked text within its existing cell after review.",
+                            atomic_group=atomic_group,
+                        )
+                        result.patches.append(wrap_patch)
+                        patches.append(wrap_patch)
+                    if row_patch is not None and cell.column not in width_patches:
+                        patches.append(row_patch)
+                    if issue_kind == "horizontal":
+                        summary = "Unwrapped text exceeds its cell and natural overflow is blocked"
+                        explanation = (
+                            "The text is wider than the available cell width and either an adjacent value "
+                            "or a visible border prevents a clean natural overflow."
+                        )
+                    else:
+                        summary = "Wrapped or multiline text exceeds an explicit row height"
+                        explanation = (
+                            "Static text measurement indicates that the saved explicit row height is too "
+                            "small for all wrapped lines."
+                        )
+                    result.findings.append(
+                        _make_finding(
+                            context=context,
+                            rule_id=self.rule_id,
+                            title=self.title,
+                            explanation=explanation,
+                            severity=Severity.WARNING,
+                            confidence=0.96,
+                            sheet=worksheet.title,
+                            location=cell.coordinate,
+                            evidence=Evidence(
+                                summary=summary,
+                                observed={
+                                    "available_width": round(measurement.available_width, 2),
+                                    "required_width": round(measurement.required_width, 2),
+                                    "current_row_height": effective_height,
+                                    "wrap_text": bool(cell.alignment.wrap_text),
+                                },
+                                expected=(
+                                    {
+                                        "estimated_column_width": shared_width_patch.after["width"],
+                                        "strategy": "shared_column_width",
+                                    }
+                                    if shared_width_patch is not None
+                                    else {
+                                        "required_lines": measurement.required_lines,
+                                        "estimated_row_height": proposed_height,
+                                        "strategy": "local_wrap_and_row_height",
+                                    }
+                                ),
+                                details={"merged_range": measurement.merged_range},
+                            ),
+                            expected="Visible text remains inside its intended cell boundary without clipping.",
+                            suggested_action=(
+                                "The row would exceed Excel's maximum height; widen the layout or shorten "
+                                "the content manually."
+                                if not patches and proposed_height > MAX_EXCEL_ROW_HEIGHT
+                                else "Review the proposed local wrap/row-height change in Excel; font "
+                                "rendering can vary by device."
+                            ),
+                            patches=patches,
+                            identity_discriminator=issue_kind,
+                        )
+                    )
+        return result
+
+
+class BorderEdgeInconsistencyRule(WorkbookRule):
+    rule_id = "WL017_BORDER_EDGE_INCONSISTENCY"
+    title = "Likely missing shared border edge"
+
+    def run(self, context: RuleContext) -> RuleResult:
+        result = RuleResult()
+        edge_names = ("left", "right", "top", "bottom")
+        for worksheet in context.workbook.worksheets:
+            reported_edges: set[tuple[str, int, int]] = set()
+            dense_regions = [
+                dense_region
+                for region in context.data_regions.get(worksheet.title, ())
+                if (dense_region := _dense_rectangular_border_region(worksheet, region)) is not None
+            ]
+            for region in dense_regions:
+                candidates_by_coordinate = {
+                    (cell.row, cell.column): cell
+                    for cell in worksheet._cells.values()
+                    if isinstance(cell, Cell)
+                    and region.min_row <= cell.row <= region.max_row
+                    and region.min_column <= cell.column <= region.max_column
+                    and _is_materialized_table_cell(cell)
+                    and not _is_hidden_cell(worksheet, cell)
+                    and not _is_in_merged_range(worksheet, cell.coordinate)
+                }
+                if float(region.confidence) >= 0.95:
+                    for row in range(region.min_row + 1, region.max_row):
+                        for column in range(region.min_column + 1, region.max_column):
+                            existing = worksheet._cells.get((row, column))
+                            if isinstance(existing, Cell) and _is_materialized_table_cell(existing):
+                                continue
+                            coordinate = f"{get_column_letter(column)}{row}"
+                            if existing is not None and not isinstance(existing, Cell):
+                                continue
+                            if _is_in_merged_range(worksheet, coordinate):
+                                continue
+                            neighbors = [
+                                worksheet._cells.get((row, column - 1)),
+                                worksheet._cells.get((row, column + 1)),
+                                worksheet._cells.get((row - 1, column)),
+                                worksheet._cells.get((row + 1, column)),
+                            ]
+                            if not all(
+                                isinstance(neighbor, Cell)
+                                and _is_materialized_table_cell(neighbor)
+                                and not _is_hidden_cell(worksheet, neighbor)
+                                and not _is_in_merged_range(worksheet, neighbor.coordinate)
+                                for neighbor in neighbors
+                            ):
+                                continue
+                            candidates_by_coordinate[(row, column)] = (
+                                existing
+                                if isinstance(existing, Cell)
+                                else Cell(
+                                    worksheet,
+                                    row=row,
+                                    column=column,
+                                )
+                            )
+                candidates = list(candidates_by_coordinate.values())
+                candidates.sort(
+                    key=lambda cell: (
+                        -sum(side[0] is None for side in visual_border_signature(worksheet, cell)),
+                        cell.row,
+                        cell.column,
+                    )
+                )
+                for cell in candidates:
+                    observed = visual_border_signature(worksheet, cell)
+                    edge_consensus: dict[
+                        str, tuple[str, str, tuple[Any, ...], float, int, int]
+                    ] = {}
+                    for index, edge in enumerate(edge_names):
+                        if observed[index][0] is not None:
+                            continue
+                        if _edge_is_internal_to_region(
+                            cell, edge, region
+                        ) and not _shared_edge_has_materialized_peer(worksheet, cell, edge):
+                            continue
+                        edge_key = _shared_edge_key(cell, edge)
+                        if edge_key in reported_edges:
+                            continue
+                        consensus = _parallel_border_source(worksheet, cell, edge, region)
+                        if consensus is not None:
+                            edge_consensus[edge] = consensus
+                    if not edge_consensus:
+                        continue
+                    missing_edges = list(edge_consensus)
+                    finding_confidence = min(edge_consensus[edge][3] for edge in missing_edges)
+                    expected = list(observed)
+                    for edge in missing_edges:
+                        expected[edge_names.index(edge)] = edge_consensus[edge][2]
+                    patches: list[PatchOperation] = []
+                    patchable = finding_confidence >= 0.95 and not _is_protected_target(worksheet)
+                    atomic_group = (
+                        stable_id(
+                            "atomic-border",
+                            self.rule_id,
+                            worksheet.title,
+                            cell.coordinate,
+                            missing_edges,
+                        )
+                        if patchable and len(missing_edges) > 1
+                        else None
+                    )
+                    if patchable:
+                        for edge in missing_edges:
+                            source_cell, source_edge, _, confidence, _, _ = edge_consensus[edge]
+                            edge_index = edge_names.index(edge)
+                            patch = _make_patch(
+                                kind=PatchKind.COPY_BORDER,
+                                worksheet=worksheet,
+                                cell=cell,
+                                before={
+                                    "target_edge": edge,
+                                    "signature": observed[edge_index],
+                                },
+                                after={"target_edge": edge, "source_edge": source_edge},
+                                source_cell=source_cell,
+                                confidence=confidence,
+                                description=(
+                                    f"Copy the parallel-consensus {edge} border edge after review."
+                                ),
+                                atomic_group=atomic_group,
+                            )
+                            result.patches.append(patch)
+                            patches.append(patch)
+                    reported_edges.update(_shared_edge_key(cell, edge) for edge in missing_edges)
+                    edge_details = {
+                        edge: {
+                            "confidence": edge_consensus[edge][3],
+                            "support": edge_consensus[edge][4],
+                            "population": edge_consensus[edge][5],
+                            "source": edge_consensus[edge][0],
+                        }
+                        for edge in missing_edges
+                    }
+                    result.findings.append(
+                        _make_finding(
+                            context=context,
+                            rule_id=self.rule_id,
+                            title=self.title,
+                            explanation=(
+                                "Both sides of one or more shared edges are absent inside a dense "
+                                "rectangular table, or a table perimeter edge is absent, while parallel "
+                                "edges show a stable style. A border present on either side remains "
+                                "visually continuous and is not reported."
+                            ),
+                            severity=Severity.WARNING,
+                            confidence=finding_confidence,
+                            sheet=worksheet.title,
+                            location=cell.coordinate,
+                            evidence=Evidence(
+                                summary=(
+                                    "Missing parallel-consensus edge(s): "
+                                    + ", ".join(missing_edges)
+                                ),
+                                observed=observed,
+                                expected=tuple(expected),
+                                peers=sorted({edge_consensus[edge][0] for edge in missing_edges}),
+                                details={"edge_consensus": edge_details},
+                            ),
+                            expected="Shared and perimeter table edges remain visually continuous.",
+                            suggested_action=(
+                                "Review the proposed edge-only border copy; no fill, font, or number "
+                                "format is changed. Findings below 0.95 confidence are report-only."
+                            ),
+                            patches=patches,
+                            identity_discriminator=missing_edges,
+                        )
+                    )
+        return result
+
+
+class UsedRangeInflationRule(WorkbookRule):
+    rule_id = "WL018_USED_RANGE_INFLATION"
+    title = "Format-only tail inflates the worksheet used range"
+
+    def run(self, context: RuleContext) -> RuleResult:
+        result = RuleResult()
+        for worksheet in context.workbook.worksheets:
+            tail = find_formatting_tail(worksheet)
+            if tail is None:
+                continue
+            snapshot = _sheet_snapshot(context, worksheet)
+            declared_dimension = getattr(snapshot, "declared_dimension", None)
+            content_dimension = getattr(snapshot, "content_dimension", None)
+            content_start = f"{get_column_letter(tail.content_min_column)}{tail.content_min_row}"
+            content_end = f"{get_column_letter(tail.content_max_column)}{tail.content_max_row}"
+            computed_content_dimension = (
+                content_start if content_start == content_end else f"{content_start}:{content_end}"
+            )
+            try:
+                declared_bounds = (
+                    range_boundaries(declared_dimension)
+                    if isinstance(declared_dimension, str) and declared_dimension
+                    else None
+                )
+            except ValueError:
+                declared_bounds = None
+            tail_cell_max_row = max(
+                coordinate_to_tuple(coordinate)[0] for coordinate in tail.cell_coordinates
+            )
+            minimum_declared_max_row = max(tail.content_max_row, tail_cell_max_row)
+            declared_max_row = declared_bounds[3] if declared_bounds is not None else None
+            declared_matches = bool(
+                declared_bounds
+                and declared_bounds[2] == tail.observed_max_column
+                and isinstance(declared_max_row, int)
+                and minimum_declared_max_row <= declared_max_row <= tail.observed_max_row
+            )
+            content_matches = content_dimension in {computed_content_dimension, None}
+            structure_intersection = _tail_intersects_structure(worksheet, tail)
+            anchor = min(
+                (
+                    cell
+                    for cell in worksheet._cells.values()
+                    if isinstance(cell, Cell) and cell.value is not None
+                ),
+                key=lambda cell: (cell.row, cell.column),
+            )
+            patches: list[PatchOperation] = []
+            if (
+                not _is_protected_target(worksheet)
+                and not _is_hidden_cell(worksheet, anchor)
+                and declared_matches
+                and content_matches
+                and isinstance(declared_dimension, str)
+                and isinstance(content_dimension, str)
+                and not structure_intersection
+            ):
+                patch = _make_patch(
+                    kind=PatchKind.CLEAR_FORMATTING_TAIL,
+                    worksheet=worksheet,
+                    cell=anchor,
+                    before={"dimension": declared_dimension},
+                    after={
+                        "cells": list(tail.cell_coordinates),
+                        "empty_rows": list(tail.empty_rows),
+                        "expected_dimension": declared_dimension,
+                        "result_dimension": content_dimension,
+                    },
+                    confidence=0.99,
+                    description="Clear only the exact reviewed format-only cells and empty row records.",
+                    layout_fingerprint=tail_layout_fingerprint(worksheet, tail),
+                )
+                result.patches.append(patch)
+                patches.append(patch)
+            result.findings.append(
+                _make_finding(
+                    context=context,
+                    rule_id=self.rule_id,
+                    title=self.title,
+                    explanation=(
+                        "A large, separated set of blank styled cells or empty row records extends far "
+                        "beyond the populated content. Broad column-dimension styling by itself is ignored."
+                    ),
+                    severity=Severity.WARNING,
+                    confidence=0.99 if declared_matches else 0.9,
+                    sheet=worksheet.title,
+                    location=",".join((*tail.cell_ranges, *tail.row_ranges)),
+                    evidence=Evidence(
+                        summary=(
+                            f"{tail.styled_cell_count} exact blank styled cells and "
+                            f"{len(tail.empty_rows)} empty row records form a separated tail"
+                        ),
+                        observed={
+                            "declared_dimension": declared_dimension,
+                            "tail_cell_runs": list(tail.cell_ranges),
+                            "empty_rows": list(tail.empty_rows),
+                        },
+                        expected={
+                            "content_dimension": content_dimension or computed_content_dimension
+                        },
+                        details={
+                            "structure_intersection": structure_intersection,
+                            "declared_dimension_verified": declared_matches,
+                        },
+                    ),
+                    expected="Worksheet dimensions reflect meaningful content and intentional structures.",
+                    suggested_action=(
+                        "Apply the exact-cell cleanup only after reviewing names, print settings, comments, "
+                        "links, breaks, and drawing anchors."
+                    ),
+                    patches=patches,
+                )
+            )
+        return result
+
+
+class IdentifierScientificNotationRule(WorkbookRule):
+    rule_id = "WL019_IDENTIFIER_SCIENTIFIC_NOTATION"
+    title = "Identifier may display in scientific notation"
+
+    def run(self, context: RuleContext) -> RuleResult:
+        result = RuleResult()
+        for worksheet in context.workbook.worksheets:
+            by_column: dict[int, list[tuple[Cell, Cell, str, float]]] = defaultdict(list)
+            for cell in sorted(
+                (item for item in worksheet._cells.values() if isinstance(item, Cell)),
+                key=lambda item: (item.row, item.column),
+            ):
+                if _is_hidden_cell(worksheet, cell) or cell.data_type == "f":
+                    continue
+                identifier = _integer_identifier_text(cell.value)
+                if identifier is None or len(identifier) < 10:
+                    continue
+                if (cell.number_format or "General").strip().lower() != "general":
+                    continue
+                header = _nearest_header(worksheet, cell)
+                if header is None or not _looks_like_identifier_header(header.value):
+                    continue
+                if _looks_like_measure_header(header.value):
+                    continue
+                measured_width = estimated_text_width(cell, identifier)
+                font_aware_width = math.ceil((measured_width + 0.5) * 4.0) / 4.0
+                desired_width = min(
+                    40.0,
+                    max(12.0, len(identifier) * 1.1 + 1.5, font_aware_width),
+                )
+                width_only_fixable = len(identifier) <= 11
+                if (
+                    width_only_fixable
+                    and column_width(worksheet, cell.column) >= desired_width - 0.25
+                ):
+                    continue
+                by_column[cell.column].append((cell, header, identifier, desired_width))
+            for column, candidates in sorted(by_column.items()):
+                fixable = [candidate for candidate in candidates if len(candidate[2]) <= 11]
+                width_patch: PatchOperation | None = None
+                if fixable and not _is_protected_target(worksheet):
+                    anchor = fixable[0][0]
+                    target_width = round(max(candidate[3] for candidate in fixable), 2)
+                    width_patch = _make_patch(
+                        kind=PatchKind.SET_COLUMN_WIDTH,
+                        worksheet=worksheet,
+                        cell=anchor,
+                        before={
+                            "column": get_column_letter(column),
+                            "width": column_width(worksheet, column),
+                        },
+                        after={
+                            "column": get_column_letter(column),
+                            "width": target_width,
+                        },
+                        confidence=0.99,
+                        description=(
+                            "Widen the identifier column while preserving the stored numeric value and type."
+                        ),
+                        layout_fingerprint=column_layout_fingerprint(worksheet, column),
+                    )
+                    result.patches.append(width_patch)
+                for cell, header, identifier, desired_width in candidates:
+                    patches: list[PatchOperation] = []
+                    if len(identifier) <= 11 and width_patch is not None:
+                        patches.append(width_patch)
+                    result.findings.append(
+                        _make_finding(
+                            context=context,
+                            rule_id=self.rule_id,
+                            title=self.title,
+                            explanation=(
+                                "A long integer under an identifier-like header uses General formatting "
+                                "and is wider than its column. Excel may display it in scientific notation."
+                            ),
+                            severity=Severity.ERROR if len(identifier) > 15 else Severity.WARNING,
+                            confidence=0.99,
+                            sheet=worksheet.title,
+                            location=cell.coordinate,
+                            evidence=Evidence(
+                                summary=(
+                                    "Long numeric identifier uses General format in a narrow column"
+                                    if len(identifier) <= 11
+                                    else "General format forces a long numeric identifier into scientific notation"
+                                ),
+                                observed={
+                                    "value": cell.value,
+                                    "digits": len(identifier),
+                                    "number_format": cell.number_format,
+                                    "column_width": column_width(worksheet, column),
+                                    "font_name": cell.font.name,
+                                    "font_size": cell.font.sz,
+                                },
+                                expected={
+                                    "storage": "numeric value and type preserved",
+                                    "minimum_estimated_width": (
+                                        round(desired_width, 2) if len(identifier) <= 11 else None
+                                    ),
+                                },
+                                peers=[header.coordinate],
+                                details={
+                                    "header": header.value,
+                                    "precision_recoverable": len(identifier) <= 15,
+                                    "width_only_fixable": len(identifier) <= 11,
+                                },
+                            ),
+                            expected=(
+                                "Phone, ID, account, and similar identifiers display fully without changing "
+                                "their stored value or type."
+                            ),
+                            suggested_action=(
+                                "Review the font-aware width-only proposal and source value."
+                                if len(identifier) <= 11
+                                else (
+                                    "General format still uses scientific notation for 12-15 digit integers "
+                                    "even in wide columns; choose an explicit integer format or intentional "
+                                    "text storage after semantic review."
+                                    if len(identifier) <= 15
+                                    else "The value may already have lost precision and is not auto-patched."
+                                )
+                            ),
+                            patches=patches,
+                        )
+                    )
+        return result
+
+
+class SavedViewOffContentRule(WorkbookRule):
+    rule_id = "WL020_SAVED_VIEW_OFF_CONTENT"
+    title = "Saved worksheet view may hide meaningful content"
+
+    def run(self, context: RuleContext) -> RuleResult:
+        result = RuleResult()
+        for worksheet in context.workbook.worksheets:
+            if worksheet.sheet_state != "visible":
+                continue
+            formatting_tail = find_formatting_tail(worksheet)
+            whitespace_tail = find_whitespace_tail(worksheet)
+            excluded_coordinates = {
+                coordinate
+                for tail in (formatting_tail, whitespace_tail)
+                if tail is not None
+                for coordinate in tail.cell_coordinates
+            }
+            bounds = _visible_layout_bounds(
+                worksheet,
+                excluded_coordinates=excluded_coordinates,
+            )
+            if bounds is None:
+                continue
+            min_row, min_column, max_row, max_column = bounds
+            layout_cells = [
+                cell
+                for cell in worksheet._cells.values()
+                if isinstance(cell, Cell)
+                and cell.coordinate not in excluded_coordinates
+                and min_row <= cell.row <= max_row
+                and min_column <= cell.column <= max_column
+                and not _is_hidden_cell(worksheet, cell)
+                and (
+                    (
+                        cell.value is not None
+                        and not (isinstance(cell.value, str) and not cell.value.strip())
+                    )
+                    or has_visible_border(cell)
+                    or cell.fill.fill_type not in {None, "none"}
+                    or cell.comment is not None
+                    or cell.hyperlink is not None
+                )
+            ]
+            if not layout_cells:
+                continue
+            top_left = worksheet.sheet_view.topLeftCell or "A1"
+            pane = worksheet.sheet_view.pane
+            pane_state = None if pane is None or pane.state is None else str(pane.state)
+            expected_origin = f"{get_column_letter(min_column)}{min_row}"
+            observed_origin = top_left
+            pane_offset = False
+            if pane is not None:
+                x_split = _finite_nonnegative_pane_split(pane.xSplit)
+                y_split = _finite_nonnegative_pane_split(pane.ySplit)
+                if x_split is None or y_split is None:
+                    continue
+                if pane.topLeftCell and _bounded_view_coordinate(pane.topLeftCell) is None:
+                    continue
+                if pane_state == "frozen":
+                    if not x_split.is_integer() or not y_split.is_integer():
+                        continue
+                    frozen_columns = int(x_split)
+                    frozen_rows = int(y_split)
+                    if frozen_columns > MAX_COLUMN - min_column or frozen_rows > MAX_ROW - min_row:
+                        continue
+                    expected_origin = (
+                        f"{get_column_letter(min_column + frozen_columns)}{min_row + frozen_rows}"
+                    )
+                    if pane.topLeftCell:
+                        observed_origin = pane.topLeftCell
+            observed_coordinate = _bounded_view_coordinate(observed_origin)
+            expected_coordinate = _bounded_view_coordinate(expected_origin)
+            if observed_coordinate is None or expected_coordinate is None:
+                continue
+            view_row, view_column = observed_coordinate
+            expected_row, expected_column = expected_coordinate
+            if pane is None:
+                view_off_content = view_row > expected_row or view_column > expected_column
+            elif pane_state == "frozen":
+                pane_offset = view_row > expected_row or view_column > expected_column
+                view_off_content = pane_offset
+            else:
+                view_off_content = False
+            count_compact = max_row - min_row + 1 <= 40 and max_column - min_column + 1 <= 20
+            visible_columns = [
+                column
+                for column in range(min_column, max_column + 1)
+                if not is_column_hidden(worksheet, column)
+            ]
+            visible_rows = [
+                row
+                for row in range(min_row, max_row + 1)
+                if not (
+                    (row_dimension := worksheet.row_dimensions.get(row)) is not None
+                    and row_dimension.hidden
+                )
+            ]
+            content_width, content_height, planned_width_updates, planned_height_updates = (
+                _predicted_layout_size(context, worksheet, visible_columns, visible_rows)
+            )
+            raw_width_fit_zoom = (
+                int(math.floor(CONSERVATIVE_VIEWPORT_WIDTH / content_width * 100.0 / 5.0) * 5)
+                if content_width > 0
+                else 100
+            )
+            raw_height_fit_zoom = (
+                int(math.floor(CONSERVATIVE_VIEWPORT_HEIGHT / content_height * 100.0 / 5.0) * 5)
+                if content_height > 0
+                else 100
+            )
+            raw_fit_zoom = min(raw_width_fit_zoom, raw_height_fit_zoom)
+            full_fit_zoom = (
+                min(400, raw_fit_zoom) if raw_fit_zoom >= MIN_AUTOMATIC_VIEW_ZOOM else None
+            )
+            zoom_scale = worksheet.sheet_view.zoomScale
+            saved_zoom = int(zoom_scale or 100)
+            vertical_scrolling_expected = (
+                raw_height_fit_zoom < MIN_AUTOMATIC_VIEW_ZOOM <= raw_width_fit_zoom
+            )
+            width_only_fit_zoom = (
+                min(400, raw_width_fit_zoom)
+                if vertical_scrolling_expected and zoom_scale is not None and saved_zoom > 100
+                else None
+            )
+            fit_zoom = full_fit_zoom if full_fit_zoom is not None else width_only_fit_zoom
+            compact = count_compact or fit_zoom is not None
+            zoom_too_large = compact and fit_zoom is not None and saved_zoom > fit_zoom
+            fit_below_safe_floor = count_compact and raw_width_fit_zoom < MIN_AUTOMATIC_VIEW_ZOOM
+            if not view_off_content and not zoom_too_large and not fit_below_safe_floor:
+                continue
+            content_start = f"{get_column_letter(min_column)}{min_row}"
+            anchor = min(layout_cells, key=lambda cell: (cell.row, cell.column))
+            has_pane = pane is not None
+            can_adjust_zoom = pane is None or (pane_state == "frozen" and not pane_offset)
+            after: dict[str, Any] = {}
+            if not has_pane and view_off_content:
+                after["top_left_cell"] = content_start
+            if compact and fit_zoom is not None and can_adjust_zoom:
+                # Keep one five-point step of headroom for font/rendering differences and
+                # other reviewed width changes selected from the same repair plan.
+                target_zoom = max(MIN_AUTOMATIC_VIEW_ZOOM, fit_zoom - 5)
+                if zoom_too_large and saved_zoom > target_zoom:
+                    after["zoom_scale"] = target_zoom
+                    if not has_pane:
+                        after.setdefault("top_left_cell", content_start)
+            patches: list[PatchOperation] = []
+            if after:
+                patch = _make_patch(
+                    kind=PatchKind.SET_SHEET_VIEW,
+                    worksheet=worksheet,
+                    cell=anchor,
+                    before={
+                        "top_left_cell": top_left,
+                        "pane_top_left_cell": None if pane is None else pane.topLeftCell,
+                        "zoom_scale": zoom_scale,
+                    },
+                    after=after,
+                    confidence=0.99,
+                    description=(
+                        "Reset the saved viewport when safe and reduce zoom using conservative "
+                        "two-dimensional layout estimates."
+                    ),
+                    layout_fingerprint=sheet_view_fingerprint(worksheet),
+                )
+                result.patches.append(patch)
+                patches.append(patch)
+            result.findings.append(
+                _make_finding(
+                    context=context,
+                    rule_id=self.rule_id,
+                    title=self.title,
+                    explanation=(
+                        "The saved viewport either starts beyond the intended visible layout or uses a "
+                        "zoom level that makes the intended visible layout difficult to use."
+                    ),
+                    severity=Severity.WARNING,
+                    confidence=0.99,
+                    sheet=worksheet.title,
+                    location=observed_origin,
+                    evidence=Evidence(
+                        summary=(
+                            "Compact content is too wide to fit above the automatic zoom safety floor"
+                            if fit_below_safe_floor
+                            else (
+                                "Saved zoom is too large for the visible width of a vertically "
+                                "scrollable sheet"
+                                if vertical_scrolling_expected and zoom_too_large
+                                else "Saved viewport is offset or too zoomed-in for the compact visible layout"
+                            )
+                        ),
+                        observed={
+                            "top_left_cell": top_left,
+                            "pane_top_left_cell": None if pane is None else pane.topLeftCell,
+                            "zoom_scale": zoom_scale,
+                            "estimated_content_width": round(content_width, 2),
+                            "estimated_content_height": round(content_height, 2),
+                            "estimated_width_fit_zoom": min(400, raw_width_fit_zoom),
+                            "estimated_height_fit_zoom": min(400, raw_height_fit_zoom),
+                            "estimated_fit_zoom": fit_zoom,
+                            "raw_estimated_fit_zoom": raw_fit_zoom,
+                            "pane": None if pane is None else pane.state,
+                        },
+                        expected={
+                            "top_left_cell": expected_origin,
+                            "zoom_scale": after.get("zoom_scale", zoom_scale),
+                        },
+                        details={
+                            "content_bounds": (
+                                f"{content_start}:{get_column_letter(max_column)}{max_row}"
+                            ),
+                            "compact_sheet": compact,
+                            "viewport_width_assumption": CONSERVATIVE_VIEWPORT_WIDTH,
+                            "viewport_height_assumption": CONSERVATIVE_VIEWPORT_HEIGHT,
+                            "planned_width_updates_included": planned_width_updates,
+                            "planned_height_updates_included": planned_height_updates,
+                            "fit_zoom_below_safe_floor": fit_below_safe_floor,
+                            "vertical_scrolling_expected": vertical_scrolling_expected,
+                            "pane_preserved": has_pane,
+                            "frozen_pane_offset": pane_offset,
+                            "zoom_only_with_frozen_pane": (
+                                has_pane and pane_state == "frozen" and not pane_offset
+                            ),
+                        },
+                    ),
+                    expected=(
+                        "Opening the sheet starts at the intended content origin and uses a readable zoom "
+                        "for the visible layout."
+                    ),
+                    suggested_action=(
+                        "The estimated width fit zoom is below the automatic safety floor; review the "
+                        "layout, column widths, or saved zoom manually."
+                        if fit_below_safe_floor
+                        else (
+                            "Review the frozen-pane scroll origin manually; WorkbookLens will not "
+                            "change the number of frozen rows or columns."
+                            if pane_offset
+                            else "Review the saved viewport. The proposed zoom is a conservative estimate "
+                            "for a typical desktop window, not a cross-device guarantee."
+                        )
+                    ),
+                    patches=patches,
+                )
+            )
+        return result
+
+
+class WhitespaceOnlyTailRule(WorkbookRule):
+    rule_id = "WL021_WHITESPACE_ONLY_TAIL"
+    title = "Whitespace-only cells extend beyond the visible layout"
+
+    def run(self, context: RuleContext) -> RuleResult:
+        result = RuleResult()
+        for worksheet in context.workbook.worksheets:
+            tail = find_whitespace_tail(worksheet)
+            if tail is None:
+                continue
+            snapshot = _sheet_snapshot(context, worksheet)
+            declared_dimension = getattr(snapshot, "declared_dimension", None)
+            try:
+                declared_matches = bool(
+                    isinstance(declared_dimension, str)
+                    and CellRange(declared_dimension).bounds
+                    == CellRange(tail.observed_dimension).bounds
+                )
+            except ValueError:
+                declared_matches = False
+            structure_intersection = _tail_intersects_structure(worksheet, tail)
+            formula_blocker = _tail_has_formula_blocker(context, worksheet, tail)
+            formatting_tail_present = find_formatting_tail(worksheet) is not None
+            target_coordinates = set(tail.cell_coordinates)
+            anchor = min(
+                (
+                    cell
+                    for cell in worksheet._cells.values()
+                    if isinstance(cell, Cell)
+                    and cell.coordinate not in target_coordinates
+                    and cell.value is not None
+                    and not (isinstance(cell.value, str) and not cell.value.strip())
+                ),
+                key=lambda cell: (cell.row, cell.column),
+                default=worksheet[tail.cell_coordinates[0]],
+            )
+            patches: list[PatchOperation] = []
+            if (
+                worksheet.sheet_state == "visible"
+                and not _is_protected_target(worksheet)
+                and declared_matches
+                and not structure_intersection
+                and not formula_blocker
+                and not formatting_tail_present
+                and isinstance(anchor, Cell)
+            ):
+                patch = _make_patch(
+                    kind=PatchKind.REMOVE_WHITESPACE_TAIL_CELLS,
+                    worksheet=worksheet,
+                    cell=anchor,
+                    before={"dimension": declared_dimension},
+                    after={
+                        "cells": list(tail.cell_coordinates),
+                        "expected_dimension": tail.observed_dimension,
+                        "preserve_style_ids": dict(tail.preserve_style_ids),
+                        "result_dimension": tail.result_dimension,
+                        "preserve_row_dimensions": True,
+                    },
+                    confidence=0.99,
+                    description=(
+                        "Remove reviewed default-style whitespace nodes and clear only the values "
+                        "of non-default-style cells, preserving their styles and row dimensions."
+                    ),
+                    layout_fingerprint=whitespace_tail_layout_fingerprint(worksheet, tail),
+                )
+                result.patches.append(patch)
+                patches.append(patch)
+            result.findings.append(
+                _make_finding(
+                    context=context,
+                    rule_id=self.rule_id,
+                    title=self.title,
+                    explanation=(
+                        "A connected tail of literal whitespace strings extends the worksheet cell "
+                        "bounds beyond its visible content. These cells can render as stray values in "
+                        "some preview tools even though Excel shows them as blank."
+                    ),
+                    severity=Severity.WARNING,
+                    confidence=0.99 if patches else 0.9,
+                    sheet=worksheet.title,
+                    location=",".join(tail.cell_ranges),
+                    evidence=Evidence(
+                        summary=(
+                            f"{len(tail.cell_coordinates)} literal-whitespace cells form an outer tail"
+                        ),
+                        observed={
+                            "cell_runs": list(tail.cell_ranges),
+                            "declared_dimension": declared_dimension,
+                            "observed_dimension": tail.observed_dimension,
+                            "preserved_style_cells": dict(tail.preserve_style_ids),
+                        },
+                        expected={"result_dimension": tail.result_dimension},
+                        details={
+                            "row_dimensions_preserved": True,
+                            "cell_styles_preserved": True,
+                            "structure_intersection": structure_intersection,
+                            "formula_blocker": formula_blocker,
+                            "formatting_tail_cleanup_first": formatting_tail_present,
+                            "declared_dimension_verified": declared_matches,
+                        },
+                    ),
+                    expected=(
+                        "Literal whitespace values outside the intended layout are cleared; only "
+                        "intentional non-default style nodes may continue to define stored bounds."
+                    ),
+                    suggested_action=(
+                        "Apply the exact value cleanup after reviewing the preserved cell styles and "
+                        "blank-row layout."
+                        if patches
+                        else "Review the referenced structure or formula blocker; no automatic cleanup is offered."
+                    ),
+                    patches=patches,
+                )
+            )
+        return result
+
+
 BUILTIN_RULES: tuple[type[WorkbookRule], ...] = (
     BrokenReferenceRule,
     FormulaPatternOutlierRule,
@@ -1906,4 +3665,10 @@ BUILTIN_RULES: tuple[type[WorkbookRule], ...] = (
     BrokenDefinedNameRule,
     MergedCellInDataRegionRule,
     InconsistentDataValidationRule,
+    TextDisplayRiskRule,
+    BorderEdgeInconsistencyRule,
+    UsedRangeInflationRule,
+    IdentifierScientificNotationRule,
+    SavedViewOffContentRule,
+    WhitespaceOnlyTailRule,
 )

--- a/src/workbooklens/scanner.py
+++ b/src/workbooklens/scanner.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from workbooklens.models import SEVERITY_RANK, Finding, PatchOperation, WorkbookSnapshot
+from workbooklens.models import SEVERITY_RANK, Finding, PatchKind, PatchOperation, WorkbookSnapshot
 from workbooklens.ooxml.formula_ranges import find_unsupported_formula_ranges
 from workbooklens.ooxml.safety import PackageInspection, PackageLimits, inspect_package
 from workbooklens.regions import infer_data_regions, infer_formula_bands
@@ -23,6 +23,67 @@ class ScanResult:
     snapshot: WorkbookSnapshot
     findings: list[Finding]
     patches: list[PatchOperation]
+
+
+def _normalize_column_width_patches(
+    findings: list[Finding],
+    patches: list[PatchOperation],
+) -> tuple[list[Finding], list[PatchOperation]]:
+    """Collapse monotonic same-column width requests to their sufficient maximum."""
+
+    groups: dict[tuple[str, str], list[PatchOperation]] = {}
+    for patch in patches:
+        if patch.kind != PatchKind.SET_COLUMN_WIDTH or not isinstance(patch.after, dict):
+            continue
+        column = patch.after.get("column")
+        width = patch.after.get("width")
+        if (
+            not isinstance(column, str)
+            or isinstance(width, bool)
+            or not isinstance(width, (int, float))
+        ):
+            continue
+        groups.setdefault((patch.sheet, column.upper()), []).append(patch)
+    replacement: dict[str, str] = {}
+    removed: set[str] = set()
+    for group in groups.values():
+        if len(group) < 2:
+            continue
+        if any(patch.atomic_group is not None for patch in group):
+            continue
+        chosen = sorted(
+            group,
+            key=lambda patch: (-float(patch.after["width"]), patch.id),
+        )[0]
+        for patch in group:
+            replacement[patch.id] = chosen.id
+            if patch.id != chosen.id:
+                removed.add(patch.id)
+    normalized_patches = [patch for patch in patches if patch.id not in removed]
+    by_id = {patch.id: patch for patch in normalized_patches}
+    normalized_findings: list[Finding] = []
+    for finding in findings:
+        identifiers: list[str] = []
+        for patch_id in finding.patch_ids:
+            normalized = replacement.get(patch_id, patch_id)
+            if normalized not in identifiers:
+                identifiers.append(normalized)
+        missing = [patch_id for patch_id in identifiers if patch_id not in by_id]
+        if missing:
+            raise RuntimeError(
+                f"Finding {finding.id} references missing patches: {', '.join(sorted(missing))}"
+            )
+        normalized_findings.append(
+            finding.model_copy(
+                update={
+                    "patch_ids": identifiers,
+                    "safe_patch_available": any(
+                        by_id[patch_id].safe_only_eligible for patch_id in identifiers
+                    ),
+                }
+            )
+        )
+    return normalized_findings, normalized_patches
 
 
 def scan_workbook(
@@ -72,7 +133,13 @@ def scan_workbook(
                     )
                 finding_by_id[finding.id] = finding
             for patch in rule_result.patches:
+                existing = patch_by_id.get(patch.id)
+                if existing is not None and existing.model_dump(mode="json") != patch.model_dump(
+                    mode="json"
+                ):
+                    raise RuntimeError(f"Conflicting patch identity generated: {patch.id}")
                 patch_by_id[patch.id] = patch
+            context.prior_patches = tuple(patch_by_id.values())
         if inspection.format == "xlsm":
             finding_by_id = {
                 finding_id: finding.model_copy(
@@ -81,8 +148,12 @@ def scan_workbook(
                 for finding_id, finding in finding_by_id.items()
             }
             patch_by_id.clear()
+        normalized_findings, normalized_patches = _normalize_column_width_patches(
+            list(finding_by_id.values()),
+            list(patch_by_id.values()),
+        )
         findings = sorted(
-            finding_by_id.values(),
+            normalized_findings,
             key=lambda finding: (
                 -SEVERITY_RANK[finding.severity],
                 finding.rule_id,
@@ -92,7 +163,7 @@ def scan_workbook(
             ),
         )
         patches = sorted(
-            patch_by_id.values(), key=lambda patch: (patch.sheet, patch.cell, patch.kind, patch.id)
+            normalized_patches, key=lambda patch: (patch.sheet, patch.cell, patch.kind, patch.id)
         )
         return ScanResult(
             inspection=inspection,

--- a/src/workbooklens/snapshot.py
+++ b/src/workbooklens/snapshot.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+import posixpath
+import zipfile
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from lxml import etree
 from openpyxl import load_workbook
 from openpyxl.cell.cell import Cell
+from openpyxl.utils.cell import get_column_letter
 from openpyxl.workbook.workbook import Workbook
 from openpyxl.worksheet.formula import ArrayFormula, DataTableFormula
 from openpyxl.worksheet.worksheet import Worksheet
 
+from workbooklens.exceptions import PatchValidationError
 from workbooklens.models import CellSnapshot, SheetSnapshot, WorkbookSnapshot
-from workbooklens.ooxml.safety import PackageLimits, inspect_package
+from workbooklens.ooxml.safety import PackageLimits, inspect_package, parse_xml_part
 from workbooklens.utils import sha256_bytes, sha256_file, stable_json_bytes
 from workbooklens.worksheet_state import hidden_column_labels, is_column_hidden
 
@@ -51,9 +56,12 @@ def cell_semantic_payload(cell: Cell) -> dict[str, Any]:
 
 
 def cell_fingerprint(cell: Cell) -> str:
-    """Hash the semantic state relevant to every supported patch operation."""
+    """Hash effective cell semantics without workbook-local style table IDs."""
 
-    return sha256_bytes(stable_json_bytes(cell_semantic_payload(cell)))
+    payload = cell_semantic_payload(cell)
+    payload.pop("style_id", None)
+    payload["style_fingerprint"] = style_fingerprint(cell)
+    return sha256_bytes(stable_json_bytes(payload))
 
 
 def _xml_component_payload(component: Any) -> dict[str, Any]:
@@ -113,10 +121,11 @@ def _snapshot_cell(cell: Cell, worksheet: Worksheet) -> CellSnapshot:
     payload = cell_semantic_payload(cell)
     snapshot_payload = dict(payload)
     snapshot_payload.pop("quote_prefix", None)
+    row_dimension = worksheet.row_dimensions.get(cell.row)
     return CellSnapshot(
         **snapshot_payload,
         style_fingerprint=style_fingerprint(cell),
-        row_hidden=bool(worksheet.row_dimensions[cell.row].hidden),
+        row_hidden=bool(row_dimension.hidden) if row_dimension is not None else False,
         column_hidden=is_column_hidden(worksheet, cell.column),
     )
 
@@ -131,9 +140,127 @@ def _defined_names(workbook: Workbook) -> dict[str, str]:
     return dict(sorted(names.items()))
 
 
+def _resolve_part(base_part: str, target: str) -> str:
+    """Resolve one internal OOXML relationship without allowing package-root escape."""
+
+    if "\\" in target or "\x00" in target:
+        raise PatchValidationError(f"Unsafe relationship target: {target!r}")
+    candidate = (
+        target.lstrip("/")
+        if target.startswith("/")
+        else posixpath.join(posixpath.dirname(base_part), target)
+    )
+    normalized = posixpath.normpath(candidate)
+    if normalized in {"", ".", ".."} or normalized.startswith("../"):
+        raise PatchValidationError(f"Relationship target escapes package root: {target!r}")
+    return normalized
+
+
+def _declared_sheet_dimensions(path: Path) -> dict[str, str | None]:
+    """Read raw worksheet ``dimension`` refs before openpyxl normalizes sparse state."""
+
+    with zipfile.ZipFile(path, "r") as archive:
+        workbook_part = "xl/workbook.xml"
+        relationships_part = "xl/_rels/workbook.xml.rels"
+        workbook_root = parse_xml_part(archive.read(workbook_part), workbook_part)
+        relationships_root = parse_xml_part(archive.read(relationships_part), relationships_part)
+        relationships: dict[str, tuple[str, str]] = {}
+        for relationship in relationships_root:
+            if etree.QName(relationship).localname != "Relationship":
+                continue
+            identifier = relationship.get("Id")
+            target = relationship.get("Target")
+            relationship_type = relationship.get("Type", "")
+            if identifier and target:
+                relationships[identifier] = (relationship_type, target)
+
+        dimensions: dict[str, str | None] = {}
+        for sheet in workbook_root.iter():
+            if etree.QName(sheet).localname != "sheet":
+                continue
+            name = sheet.get("name")
+            relationship_id = next(
+                (
+                    value
+                    for attribute, value in sheet.attrib.items()
+                    if etree.QName(attribute).localname == "id"
+                ),
+                None,
+            )
+            if not name or not relationship_id or relationship_id not in relationships:
+                raise PatchValidationError(
+                    "Workbook contains a sheet with a malformed relationship"
+                )
+            relationship_type, target = relationships[relationship_id]
+            if relationship_type.endswith("/chartsheet"):
+                continue
+            if not relationship_type.endswith("/worksheet"):
+                raise PatchValidationError(
+                    "Workbook contains an unsupported sheet relationship type: "
+                    f"{relationship_type!r}"
+                )
+            part = _resolve_part(workbook_part, target)
+            if part not in archive.namelist():
+                raise PatchValidationError(f"Worksheet package part is missing: {part}")
+            worksheet_root = parse_xml_part(archive.read(part), part)
+            dimension = next(
+                (
+                    element
+                    for element in worksheet_root
+                    if etree.QName(element).localname == "dimension"
+                ),
+                None,
+            )
+            dimensions[name] = dimension.get("ref") if dimension is not None else None
+        return dimensions
+
+
+def _content_bounds(worksheet: Worksheet, cells: list[Cell]) -> str | None:
+    """Return content bounds while preserving the visible extent of merged ranges."""
+
+    meaningful = [cell for cell in cells if cell.value is not None]
+    row_bounds = [cell.row for cell in meaningful]
+    column_bounds = [cell.column for cell in meaningful]
+    for merged in worksheet.merged_cells.ranges:
+        row_bounds.extend((merged.min_row, merged.max_row))
+        column_bounds.extend((merged.min_col, merged.max_col))
+    if not row_bounds or not column_bounds:
+        return None
+    start = f"{get_column_letter(min(column_bounds))}{min(row_bounds)}"
+    end = f"{get_column_letter(max(column_bounds))}{max(row_bounds)}"
+    return start if start == end else f"{start}:{end}"
+
+
+def _row_heights(worksheet: Worksheet) -> dict[str, float]:
+    return {
+        str(index): float(dimension.height)
+        for index, dimension in sorted(worksheet.row_dimensions.items())
+        if dimension.height is not None
+    }
+
+
+def _column_widths(worksheet: Worksheet) -> dict[str, float]:
+    entries: list[tuple[int, int, str, float]] = []
+    for key, dimension in worksheet.column_dimensions.items():
+        if dimension.width is None:
+            continue
+        minimum = int(dimension.min or 0)
+        maximum = int(dimension.max or minimum)
+        if minimum < 1 or maximum < minimum or maximum > 16_384:
+            raise PatchValidationError(
+                f"Invalid column dimension span for {worksheet.title!r}: {key!r}"
+            )
+        start = get_column_letter(minimum)
+        end = get_column_letter(maximum)
+        label = start if start == end else f"{start}:{end}"
+        entries.append((minimum, maximum, label, float(dimension.width)))
+    return {label: width for _, _, label, width in sorted(entries)}
+
+
 def snapshot_from_workbook(workbook: Workbook, path: Path, source_sha256: str) -> WorkbookSnapshot:
     """Build a deterministic snapshot from an already-open, non-read-only workbook."""
 
+    declared_dimensions = _declared_sheet_dimensions(path)
     sheets: list[SheetSnapshot] = []
     for index, worksheet in enumerate(workbook.worksheets):
         cells: dict[str, CellSnapshot] = {}
@@ -166,6 +293,16 @@ def snapshot_from_workbook(workbook: Workbook, path: Path, source_sha256: str) -
                 state=worksheet.sheet_state,
                 max_row=max((cell.row for cell in sparse_cells), default=0),
                 max_column=max((cell.column for cell in sparse_cells), default=0),
+                declared_dimension=declared_dimensions.get(worksheet.title),
+                content_dimension=_content_bounds(worksheet, sparse_cells),
+                row_heights=_row_heights(worksheet),
+                column_widths=_column_widths(worksheet),
+                view_top_left_cell=worksheet.sheet_view.topLeftCell,
+                view_zoom_scale=(
+                    int(worksheet.sheet_view.zoomScale)
+                    if worksheet.sheet_view.zoomScale is not None
+                    else None
+                ),
                 cells=cells,
                 merged_ranges=sorted(str(item) for item in worksheet.merged_cells.ranges),
                 hidden_rows=sorted(

--- a/src/workbooklens/web/app.py
+++ b/src/workbooklens/web/app.py
@@ -9,15 +9,18 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from fastapi import FastAPI, Form, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
 from jinja2 import Environment, select_autoescape
 from starlette.concurrency import run_in_threadpool
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from workbooklens.diff import compare_workbooks, write_diff_report
 from workbooklens.exceptions import WorkbookLensError
-from workbooklens.models import Finding, PatchPlan
+from workbooklens.models import Finding, PatchPlan, PatchRisk
 from workbooklens.ooxml.safety import PackageLimits
 from workbooklens.repair import apply_patch_plan, build_patch_plan
 from workbooklens.repair.planning import write_patch_plan
@@ -25,14 +28,33 @@ from workbooklens.reports import write_scan_report
 from workbooklens.scanner import scan_workbook
 from workbooklens.utils import write_json
 
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1"})
+CSRF_COOKIE_NAME = "workbooklens_csrf"
+MAX_MULTIPART_OVERHEAD_BYTES = 16 * 1024
+MAX_FORM_BODY_BYTES = 1024 * 1024
+UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+SECURITY_HEADERS = {
+    "Cache-Control": "no-store",
+    "Content-Security-Policy": (
+        "default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; "
+        "style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src 'self' data:"
+    ),
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+
 INDEX_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1"><title>WorkbookLens</title>
 <style>:root{color-scheme:light dark;--bg:#f5f7fb;--card:#fff;--ink:#172033;--line:#dce3ee;--accent:#3157d5}
 @media(prefers-color-scheme:dark){:root{--bg:#10131a;--card:#181d27;--ink:#edf2f7;--line:#303849;--accent:#8da2ff}}
 *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.55 Arial,sans-serif}main{max-width:920px;margin:auto;padding:32px}.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:22px;margin:18px 0}button{font:inherit;background:var(--accent);color:white;border:0;border-radius:8px;padding:10px 16px;font-weight:700}input[type=file]{display:block;margin:16px 0}.privacy{border-left:5px solid var(--accent)}</style></head>
 <body><main><h1>WorkbookLens</h1><p>Lint, review, and safely repair an Excel workbook on this computer.</p>
-<section class="card privacy"><b>Private by design.</b> Files remain in a temporary local directory and are removed when this server stops. Formulas, macros, external links, and embedded objects are never executed.</section>
-<form id="scan-form" class="card" action="/scan" method="post" enctype="multipart/form-data"><h2>1. Choose a workbook</h2>
+<section class="card privacy"><b>Private by design.</b> Files remain in a process-owned temporary local directory and are removed on normal server shutdown. An abrupt crash or power loss can leave temporary files until they are removed manually or by operating-system cleanup. Formulas, macros, external links, and embedded objects are never executed.</section>
+<form id="scan-form" class="card" action="/scan" method="post" enctype="multipart/form-data"><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><h2>1. Choose a workbook</h2>
 <label for="workbook">Supported: .xlsx; .xlsm is scan-only</label><input id="workbook" name="workbook" type="file" accept=".xlsx,.xlsm" required>
 <button id="scan-button" type="submit">Scan locally</button><p id="scan-status" aria-live="polite">The upload limit is {{ max_mb }} MB.</p></form></main>
 <script>document.querySelector('#scan-form').addEventListener('submit',()=>{const button=document.querySelector('#scan-button');button.disabled=true;button.textContent='Scanning…';document.querySelector('#scan-status').textContent='Validating the package and running deterministic rules locally…'});</script></body></html>"""
@@ -41,8 +63,10 @@ RESULT_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
 <style>:root{color-scheme:light dark;--bg:#f5f7fb;--card:#fff;--ink:#172033;--line:#dce3ee;--accent:#3157d5;--error:#c24135;--warning:#a15c00;--info:#1769aa}
 @media(prefers-color-scheme:dark){:root{--bg:#10131a;--card:#181d27;--ink:#edf2f7;--line:#303849;--accent:#8da2ff}}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.5 Arial,sans-serif}main{max-width:1100px;margin:auto;padding:28px}.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px;margin:16px 0}.finding{border-left:5px solid var(--info)}.finding.error,.finding.critical{border-left-color:var(--error)}.finding.warning{border-left-color:var(--warning)}button,.button{display:inline-block;font:inherit;background:var(--accent);color:white;border:0;border-radius:8px;padding:9px 14px;text-decoration:none;font-weight:700}code{overflow-wrap:anywhere}.actions{display:flex;gap:10px;flex-wrap:wrap}label.patch{display:block;padding:10px;border:1px solid var(--line);border-radius:8px;margin:8px 0}</style></head>
 <body><main><a href="/">← New scan</a><h1>Findings for {{ filename }}</h1><div class="actions"><a class="button" href="/sessions/{{ session_id }}/report">Open full HTML report</a><a class="button" href="/sessions/{{ session_id }}/plan">Download JSON plan</a></div>
-<form class="card" action="/sessions/{{ session_id }}/apply" method="post"><h2>2. Review safe patches</h2>
-{% if patches %}<p>Select only changes you have reviewed. The original file is never modified.</p>{% for patch in patches %}<label class="patch"><input type="checkbox" name="patch_id" value="{{ patch.id }}"> <b>{{ patch.sheet }}!{{ patch.cell }}</b> · {{ patch.kind.value }} · {{ '%.0f'|format(patch.confidence.root*100) }}% confidence<br><code>{{ patch.before }}</code> → <code>{{ patch.after }}</code><br>{{ patch.description }}</label>{% endfor %}<button type="submit">Apply selected patches to a copy</button>{% else %}<p>No safe deterministic patches are available. Scan and report downloads remain available.</p>{% endif %}</form>
+<form class="card" action="/sessions/{{ session_id }}/apply" method="post"><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><h2>2. Review patches</h2>
+{% if patches %}<p>Select only changes you have reviewed. The original file is never modified.</p>{% for patch in patches %}<label class="patch"><input type="checkbox" name="patch_id" value="{{ patch.id }}" data-risk="{{ patch.risk.value }}"> <b>{{ patch.sheet }}!{{ patch.cell }}</b> · {{ patch.kind.value }} · {{ '%.0f'|format(patch.confidence.root*100) }}% confidence · {{ patch.risk.value }}<br><code>{{ patch.before }}</code> → <code>{{ patch.after }}</code><br>{{ patch.description }}</label>{% endfor %}
+{% if has_layout_review %}<label class="patch"><input type="checkbox" name="accept_layout_risk" value="true"> <b>I reviewed the layout risk.</b> Row heights, column widths, saved view, wrapping, borders, or print pagination may change. Atomic patch groups are always applied together.</label>{% endif %}
+<button type="submit">Apply selected patches to a copy</button>{% else %}<p>No safe deterministic patches are available, and no layout-review patches were offered. Scan and report downloads remain available.</p>{% endif %}</form>
 <section><h2>All findings ({{ findings|length }})</h2>{% for finding in findings %}<article class="card finding {{ finding.severity.value }}"><b>{{ finding.severity.value|upper }} · {{ finding.rule_id }} · {{ finding.sheet or 'Workbook' }}{% if finding.location %}!{{ finding.location }}{% endif %}</b><h3>{{ finding.title }}</h3><p>{{ finding.explanation }}</p><details><summary>Evidence</summary><p>{{ finding.evidence.summary }}</p><code>{{ finding.evidence.observed }}</code></details></article>{% endfor %}{% if not findings %}<div class="card">No findings.</div>{% endif %}</section></main></body></html>"""
 
 APPLIED_TEMPLATE = """<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>WorkbookLens repair complete</title><style>:root{color-scheme:light dark;--bg:#f5f7fb;--card:#fff;--ink:#172033;--line:#dce3ee;--accent:#3157d5}body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.55 Arial,sans-serif}main{max-width:850px;margin:auto;padding:32px}.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:20px;margin:16px 0}.button{display:inline-block;background:var(--accent);color:white;border-radius:8px;padding:10px 15px;text-decoration:none;font-weight:700;margin:5px}</style></head><body><main><h1>Validated copy created</h1><section class="card"><p>Applied {{ result.applied_patch_ids|length }} reviewed patches. The source hash remained {{ result.source_sha256 }}.</p><p>{{ result.resolved_finding_ids|length }} findings resolved; {{ result.new_finding_ids|length }} new informational/warning findings.</p>{% for message in result.validation_messages %}<p>✓ {{ message }}</p>{% endfor %}</section><div><a class="button" href="/sessions/{{ session_id }}/fixed">Download fixed workbook</a><a class="button" href="/sessions/{{ session_id }}/diff">Preview semantic diff</a><a class="button" href="/sessions/{{ session_id }}/apply-report">Download apply report</a></div></main></body></html>"""
@@ -65,8 +89,182 @@ class WebSession:
     apply_report: Path | None = None
 
 
+@dataclass(slots=True)
+class _LimitedReceive:
+    receive: Receive
+    maximum: int
+    received: int = 0
+    exceeded: bool = False
+
+    async def __call__(self) -> Message:
+        if self.exceeded:
+            return {"type": "http.disconnect"}
+        message = await self.receive()
+        if message["type"] == "http.request":
+            self.received += len(message.get("body", b""))
+            if self.received > self.maximum:
+                self.exceeded = True
+                return {"type": "http.disconnect"}
+        return message
+
+
 def _environment() -> Environment:
     return Environment(autoescape=select_autoescape(default=True))
+
+
+def _parse_local_authority(authority: str) -> tuple[str, int | None] | None:
+    if not authority or authority != authority.strip():
+        return None
+    host, separator, port_text = authority.partition(":")
+    host = host.lower()
+    if host not in LOCAL_HOSTS:
+        return None
+    if not separator:
+        return host, None
+    if not port_text or not port_text.isascii() or not port_text.isdigit():
+        return None
+    port = int(port_text)
+    if not 1 <= port <= 65535:
+        return None
+    return host, port
+
+
+def _origin(value: str) -> tuple[str, str, int] | None:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return None
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if (
+        scheme not in {"http", "https"}
+        or host not in LOCAL_HOSTS
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        return None
+    if port is None:
+        port = 443 if scheme == "https" else 80
+    if not 1 <= port <= 65535:
+        return None
+    return scheme, host, port
+
+
+def _validate_post_request(request: Request, csrf_token: str) -> None:
+    request_origin = _origin(str(request.url))
+    for header in ("origin", "referer"):
+        value = request.headers.get(header)
+        if value is not None and _origin(value) != request_origin:
+            raise HTTPException(status_code=403, detail="Cross-origin form submission rejected")
+    expected = str(request.app.state.csrf_token)
+    if not csrf_token or not secrets.compare_digest(csrf_token, expected):
+        raise HTTPException(status_code=403, detail="Invalid or missing form security token")
+
+
+def _content_length(scope: Scope) -> int | None:
+    values = [
+        value.strip()
+        for name, value in scope.get("headers", [])
+        if name.lower() == b"content-length"
+    ]
+    if not values:
+        return None
+    if len(values) != 1 or not values[0] or not values[0].isascii() or not values[0].isdigit():
+        raise ValueError("Invalid Content-Length header")
+    return int(values[0])
+
+
+def _request_body_limit(path: str, max_file_bytes: int) -> int:
+    if path == "/scan":
+        return max_file_bytes + MAX_MULTIPART_OVERHEAD_BYTES
+    return MAX_FORM_BODY_BYTES
+
+
+class _LocalRequestGuard:
+    """Reject unsafe local requests before FastAPI parses form or multipart bodies."""
+
+    def __init__(self, app: ASGIApp, *, max_file_bytes: int, csrf_token: str) -> None:
+        self.app = app
+        self.max_file_bytes = max_file_bytes
+        self.csrf_token = csrf_token
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope)
+        response_started = False
+        limited_receive: _LimitedReceive | None = None
+
+        async def secure_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+                headers = MutableHeaders(scope=message)
+                for name, value in SECURITY_HEADERS.items():
+                    headers[name] = value
+            await send(message)
+
+        async def guarded_send(message: Message) -> None:
+            if limited_receive is not None and limited_receive.exceeded:
+                return
+            await secure_send(message)
+
+        async def reject(status_code: int, detail: str) -> None:
+            response = PlainTextResponse(detail, status_code=status_code)
+            await response(scope, receive, secure_send)
+
+        if _parse_local_authority(request.headers.get("host", "")) is None:
+            await reject(400, "Invalid Host header")
+            return
+
+        if request.method not in UNSAFE_METHODS:
+            await self.app(scope, receive, secure_send)
+            return
+
+        request_origin = _origin(str(request.url))
+        for header in ("origin", "referer"):
+            value = request.headers.get(header)
+            if value is not None and _origin(value) != request_origin:
+                await reject(403, "Cross-origin form submission rejected")
+                return
+
+        csrf_cookie = request.cookies.get(CSRF_COOKIE_NAME, "")
+        if not csrf_cookie or not secrets.compare_digest(csrf_cookie, self.csrf_token):
+            await reject(403, "Invalid or missing form security cookie")
+            return
+
+        try:
+            declared_length = _content_length(scope)
+        except ValueError:
+            await reject(400, "Invalid Content-Length header")
+            return
+
+        body_limit = _request_body_limit(request.url.path, self.max_file_bytes)
+        content_type = request.headers.get("content-type", "").partition(";")[0].strip().lower()
+        if (
+            request.url.path == "/scan"
+            and content_type == "multipart/form-data"
+            and declared_length is None
+        ):
+            await reject(411, "Multipart uploads require a Content-Length header")
+            return
+        if declared_length is not None and declared_length > body_limit:
+            await reject(413, "Request body exceeds the configured upload limit")
+            return
+
+        limited_receive = _LimitedReceive(receive, body_limit)
+        try:
+            await self.app(scope, limited_receive, guarded_send)
+        except Exception:
+            if not limited_receive.exceeded:
+                raise
+        if limited_receive.exceeded:
+            if response_started:
+                raise RuntimeError("Request body limit was exceeded after the response started")
+            await reject(413, "Request body exceeds the configured upload limit")
 
 
 async def _store_upload(upload: UploadFile, target: Path, maximum: int) -> None:
@@ -103,6 +301,12 @@ def create_app(*, max_file_bytes: int = 100 * 1024 * 1024) -> FastAPI:
         lifespan=lifespan,
     )
     environment = _environment()
+    app.state.csrf_token = secrets.token_urlsafe(32)
+    app.add_middleware(
+        _LocalRequestGuard,
+        max_file_bytes=max_file_bytes,
+        csrf_token=app.state.csrf_token,
+    )
 
     def error_page(message: str, status_code: int) -> HTMLResponse:
         html = environment.from_string(ERROR_TEMPLATE).render(message=message)
@@ -121,11 +325,29 @@ def create_app(*, max_file_bytes: int = 100 * 1024 * 1024) -> FastAPI:
         return {"status": "ok"}
 
     @app.get("/", response_class=HTMLResponse)
-    async def index() -> str:
-        return environment.from_string(INDEX_TEMPLATE).render(max_mb=max_file_bytes // 1024**2)
+    async def index() -> HTMLResponse:
+        response = HTMLResponse(
+            environment.from_string(INDEX_TEMPLATE).render(
+                max_mb=max_file_bytes // 1024**2,
+                csrf_token=app.state.csrf_token,
+            )
+        )
+        response.set_cookie(
+            CSRF_COOKIE_NAME,
+            app.state.csrf_token,
+            httponly=True,
+            samesite="strict",
+            path="/",
+        )
+        return response
 
     @app.post("/scan", response_class=HTMLResponse)
-    async def scan_upload(request: Request, workbook: UploadFile) -> str:
+    async def scan_upload(
+        request: Request,
+        workbook: UploadFile,
+        csrf_token: str = Form(default=""),
+    ) -> str:
+        _validate_post_request(request, csrf_token)
         filename = Path(workbook.filename or "workbook.xlsx").name
         suffix = Path(filename).suffix.lower()
         if suffix not in {".xlsx", ".xlsm"}:
@@ -158,12 +380,24 @@ def create_app(*, max_file_bytes: int = 100 * 1024 * 1024) -> FastAPI:
             plan=plan,
             findings=scan.findings,
         )
-        safe_patches = [] if suffix == ".xlsm" else [patch for patch in plan.patches if patch.safe]
+        reviewable_patches = (
+            []
+            if suffix == ".xlsm"
+            else [
+                patch
+                for patch in plan.patches
+                if patch.safe_only_eligible or patch.risk == PatchRisk.LAYOUT_REVIEW
+            ]
+        )
         return environment.from_string(RESULT_TEMPLATE).render(
             session_id=session_id,
             filename=filename,
             findings=scan.findings,
-            patches=safe_patches,
+            patches=reviewable_patches,
+            csrf_token=app.state.csrf_token,
+            has_layout_review=any(
+                patch.risk == PatchRisk.LAYOUT_REVIEW for patch in reviewable_patches
+            ),
         )
 
     def session_or_404(session_id: str) -> WebSession:
@@ -192,8 +426,12 @@ def create_app(*, max_file_bytes: int = 100 * 1024 * 1024) -> FastAPI:
     @app.post("/sessions/{session_id}/apply", response_class=HTMLResponse)
     async def apply_selected(
         session_id: str,
+        request: Request,
+        csrf_token: str = Form(default=""),
         patch_id: list[str] = Form(default=[]),
+        accept_layout_risk: bool = Form(default=False),
     ) -> str:
+        _validate_post_request(request, csrf_token)
         session = session_or_404(session_id)
         if not patch_id:
             raise HTTPException(status_code=400, detail="Select at least one reviewed patch")
@@ -205,6 +443,7 @@ def create_app(*, max_file_bytes: int = 100 * 1024 * 1024) -> FastAPI:
             session.plan,
             fixed,
             selected_ids=set(patch_id),
+            accept_layout_risk=accept_layout_risk,
         )
         apply_report = session.source.parent / "apply-report.json"
         write_json(apply_report, result.model_dump(mode="json"))

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 from openpyxl import Workbook
 from typer.testing import CliRunner
@@ -10,6 +11,13 @@ from typer.testing import CliRunner
 import workbooklens.cli as cli_module
 from workbooklens.cli import app
 from workbooklens.demo.workflow import generate_demo_workbook
+from workbooklens.models import (
+    PatchKind,
+    PatchOperation,
+    PatchPlan,
+    PatchPrecondition,
+    PatchRisk,
+)
 from workbooklens.utils import sha256_file
 
 runner = CliRunner()
@@ -22,7 +30,62 @@ def test_help_version_and_required_commands() -> None:
         assert command in help_result.stdout
     version_result = runner.invoke(app, ["--version"])
     assert version_result.exit_code == 0
-    assert "WorkbookLens 2.1.0" in version_result.stdout
+    assert "WorkbookLens 2.2.0" in version_result.stdout
+
+
+def test_apply_help_explains_layout_review_opt_in() -> None:
+    result = runner.invoke(app, ["apply", "--help"])
+
+    assert result.exit_code == 0
+    assert "--accept-layout-risk" in result.stdout
+    assert "--safe-only" in result.stdout
+    assert "layout-review" in result.stdout
+
+
+def test_plan_reports_safe_and_layout_review_counts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    safe_patch = PatchOperation(
+        id="safe-patch",
+        kind=PatchKind.SET_FORMULA,
+        sheet="Sheet1",
+        cell="A1",
+        after="=1+1",
+        confidence=0.99,
+        safe=True,
+        description="safe test patch",
+        precondition=PatchPrecondition(cell_fingerprint="safe-fingerprint"),
+    )
+    review_patch = PatchOperation(
+        id="review-patch",
+        kind=PatchKind.SET_COLUMN_WIDTH,
+        sheet="Sheet1",
+        cell="A1",
+        before=8.43,
+        after=16.0,
+        confidence=0.99,
+        safe=False,
+        risk=PatchRisk.LAYOUT_REVIEW,
+        description="layout test patch",
+        precondition=PatchPrecondition(cell_fingerprint="review-fingerprint"),
+    )
+    patch_plan = PatchPlan(
+        tool_version="2.1.0",
+        source_name="input.xlsx",
+        source_sha256="abc123",
+        patches=[safe_patch, review_patch],
+    )
+    monkeypatch.setattr(cli_module, "scan_workbook", lambda *args, **kwargs: object())
+    monkeypatch.setattr(cli_module, "build_patch_plan", lambda _scan: patch_plan)
+
+    result = runner.invoke(
+        app,
+        ["plan", str(tmp_path / "input.xlsx"), "--out", str(tmp_path / "plan.json")],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "(1 safe, 1 layout review)" in result.stdout
 
 
 def test_scan_outputs_and_fail_on_exit_code(tmp_path: Path) -> None:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from click import unstyle
 from openpyxl import Workbook
 from typer.testing import CliRunner
 
@@ -34,12 +35,18 @@ def test_help_version_and_required_commands() -> None:
 
 
 def test_apply_help_explains_layout_review_opt_in() -> None:
-    result = runner.invoke(app, ["apply", "--help"])
+    result = runner.invoke(
+        app,
+        ["apply", "--help"],
+        color=False,
+        terminal_width=160,
+    )
+    help_text = unstyle(result.stdout)
 
     assert result.exit_code == 0
-    assert "--accept-layout-risk" in result.stdout
-    assert "--safe-only" in result.stdout
-    assert "layout-review" in result.stdout
+    assert "--accept-layout-risk" in help_text
+    assert "--safe-only" in help_text
+    assert "layout-review" in help_text
 
 
 def test_plan_reports_safe_and_layout_review_counts(

--- a/tests/integration/test_layout_adversarial_regression.py
+++ b/tests/integration/test_layout_adversarial_regression.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from lxml import etree
+from openpyxl import Workbook, load_workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Protection, Side
+
+from workbooklens.repair import apply_patch_plan, build_patch_plan
+from workbooklens.scanner import ScanResult, scan_workbook
+
+LAYOUT_RULES = {
+    "WL016_TEXT_DISPLAY_RISK",
+    "WL017_BORDER_EDGE_INCONSISTENCY",
+    "WL018_USED_RANGE_INFLATION",
+    "WL020_SAVED_VIEW_OFF_CONTENT",
+    "WL021_WHITESPACE_ONLY_TAIL",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LayoutCase:
+    name: str
+    build: Callable[[Path], dict[str, Any]]
+    expected_findings: frozenset[str]
+    repaired_rules: frozenset[str]
+    remaining_rules: frozenset[str] = frozenset()
+
+
+def _thin() -> Side:
+    return Side(style="thin", color="FF000000")
+
+
+def _full_border() -> Border:
+    thin = _thin()
+    return Border(left=thin, right=thin, top=thin, bottom=thin)
+
+
+def _populate_grid(
+    worksheet: Any,
+    *,
+    rows: int,
+    columns: int,
+    width: float = 10.0,
+    height: float = 18.0,
+) -> None:
+    border = _full_border()
+    for row in range(1, rows + 1):
+        worksheet.row_dimensions[row].height = height
+        for column in range(1, columns + 1):
+            cell = worksheet.cell(row, column, f"R{row}C{column}")
+            cell.border = border
+            if row == 1:
+                worksheet.column_dimensions[cell.column_letter].width = width
+
+
+def _remove_four_shared_edges(worksheet: Any, coordinate: str) -> None:
+    cell = worksheet[coordinate]
+    row = cell.row
+    column = cell.column
+    thin = _thin()
+    worksheet.cell(row, column).border = Border()
+    worksheet.cell(row, column - 1).border = Border(left=thin, top=thin, bottom=thin)
+    worksheet.cell(row, column + 1).border = Border(right=thin, top=thin, bottom=thin)
+    worksheet.cell(row - 1, column).border = Border(left=thin, right=thin, top=thin)
+    worksheet.cell(row + 1, column).border = Border(left=thin, right=thin, bottom=thin)
+
+
+def _save(workbook: Workbook, path: Path) -> dict[str, Any]:
+    workbook.save(path)
+    workbook.close()
+    return {}
+
+
+def _build_same_cell_text_border_view(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Combined"
+    _populate_grid(worksheet, rows=8, columns=8, width=12.0)
+    worksheet.column_dimensions["C"].width = 6.0
+    worksheet["C3"] = "A long heading that must wrap while all four missing borders are restored"
+    worksheet.row_dimensions[3].height = 15.0
+    _remove_four_shared_edges(worksheet, "C3")
+    worksheet.sheet_view.zoomScale = 160
+    return _save(workbook, path)
+
+
+def _build_tall_boundary_grid(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "TallGrid"
+    _populate_grid(worksheet, rows=28, columns=7, width=10.0)
+    worksheet.column_dimensions["G"].width = 8.0
+    for row in range(2, 6):
+        worksheet.cell(row, 7, "Repeated text at right edge")
+        worksheet.cell(row, 7).border = _full_border()
+    thin = _thin()
+    worksheet["A12"].border = Border(right=thin, top=thin, bottom=thin)
+    worksheet["D28"].border = Border(left=thin, right=thin, top=thin)
+    worksheet.sheet_view.zoomScale = 115
+    return _save(workbook, path)
+
+
+def _build_frozen_pane_mixed(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Frozen"
+    _populate_grid(worksheet, rows=28, columns=7, width=10.0)
+    worksheet["A1"] = "Wrapped frozen heading that needs a taller first row"
+    worksheet["A1"].alignment = Alignment(wrap_text=True)
+    worksheet.row_dimensions[1].height = 15.0
+    _remove_four_shared_edges(worksheet, "D14")
+    worksheet.freeze_panes = "A2"
+    worksheet.sheet_view.zoomScale = 130
+    _save(workbook, path)
+    return {"pane_xml": _pane_xml(path)}
+
+
+def _build_split_pane_conservative(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "SplitPane"
+    _populate_grid(worksheet, rows=28, columns=7, width=10.0)
+    _remove_four_shared_edges(worksheet, "D14")
+    worksheet.freeze_panes = "A2"
+    assert worksheet.sheet_view.pane is not None
+    worksheet.sheet_view.pane.state = "split"
+    worksheet.sheet_view.zoomScale = 130
+    _save(workbook, path)
+    return {"pane_xml": _pane_xml(path)}
+
+
+def _build_formatting_tail_and_view(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "FormatTail"
+    _populate_grid(worksheet, rows=20, columns=7, width=10.0)
+    fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    for row in range(50, 54):
+        for column in range(16, 20):
+            worksheet.cell(row, column).fill = fill
+    worksheet.row_dimensions[55].height = 22.0
+    worksheet.sheet_view.zoomScale = 140
+    return _save(workbook, path)
+
+
+def _build_whitespace_tail_and_view(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "WhitespaceTail"
+    _populate_grid(worksheet, rows=8, columns=13, width=7.0)
+    for row in range(9, 12):
+        worksheet.cell(row, 1, " ")
+        worksheet.row_dimensions[row].height = 30.0
+    worksheet["A10"].font = Font(name="Aptos", italic=True)
+    worksheet["A11"].alignment = Alignment(horizontal="right")
+    worksheet["A11"].protection = Protection(locked=False, hidden=True)
+    worksheet.sheet_view.zoomScale = 140
+    _save(workbook, path)
+    reopened = load_workbook(path, data_only=False, keep_links=False)
+    try:
+        sheet = reopened["WhitespaceTail"]
+        return {
+            "style_ids": {coordinate: sheet[coordinate].style_id for coordinate in ("A10", "A11")}
+        }
+    finally:
+        reopened.close()
+
+
+def _build_merged_title_perimeter_view(path: Path) -> dict[str, Any]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "MergedTitle"
+    _populate_grid(worksheet, rows=12, columns=9, width=9.0)
+    worksheet.merge_cells("A1:I1")
+    worksheet["A1"] = (
+        "A deliberately long merged report title that should remain fully visible after repair " * 3
+    )
+    worksheet["A1"].alignment = Alignment(horizontal="center", wrap_text=True)
+    worksheet.row_dimensions[1].height = 15.0
+    thin = _thin()
+    worksheet["A6"].border = Border(right=thin, top=thin, bottom=thin)
+    worksheet["I6"].border = Border(left=thin, top=thin, bottom=thin)
+    worksheet["E12"].border = Border(left=thin, right=thin, top=thin)
+    worksheet.sheet_view.topLeftCell = "D5"
+    worksheet.sheet_view.zoomScale = 130
+    return _save(workbook, path)
+
+
+def _pane_xml(path: Path) -> bytes:
+    with zipfile.ZipFile(path) as archive:
+        root = etree.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+    panes = [element for element in root.iter() if etree.QName(element).localname == "pane"]
+    assert len(panes) == 1
+    return etree.tostring(panes[0])
+
+
+CASES = (
+    LayoutCase(
+        name="same-cell-text-border-view",
+        build=_build_same_cell_text_border_view,
+        expected_findings=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+        repaired_rules=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+    ),
+    LayoutCase(
+        name="tall-boundary-grid",
+        build=_build_tall_boundary_grid,
+        expected_findings=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+        repaired_rules=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+    ),
+    LayoutCase(
+        name="frozen-pane-mixed",
+        build=_build_frozen_pane_mixed,
+        expected_findings=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+        repaired_rules=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+    ),
+    LayoutCase(
+        name="split-pane-conservative",
+        build=_build_split_pane_conservative,
+        expected_findings=frozenset(
+            {
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+        repaired_rules=frozenset({"WL017_BORDER_EDGE_INCONSISTENCY"}),
+        remaining_rules=frozenset({"WL020_SAVED_VIEW_OFF_CONTENT"}),
+    ),
+    LayoutCase(
+        name="formatting-tail-and-view",
+        build=_build_formatting_tail_and_view,
+        expected_findings=frozenset({"WL018_USED_RANGE_INFLATION", "WL020_SAVED_VIEW_OFF_CONTENT"}),
+        repaired_rules=frozenset({"WL018_USED_RANGE_INFLATION", "WL020_SAVED_VIEW_OFF_CONTENT"}),
+    ),
+    LayoutCase(
+        name="whitespace-tail-and-view",
+        build=_build_whitespace_tail_and_view,
+        expected_findings=frozenset({"WL020_SAVED_VIEW_OFF_CONTENT", "WL021_WHITESPACE_ONLY_TAIL"}),
+        repaired_rules=frozenset({"WL020_SAVED_VIEW_OFF_CONTENT", "WL021_WHITESPACE_ONLY_TAIL"}),
+    ),
+    LayoutCase(
+        name="merged-title-perimeter-view",
+        build=_build_merged_title_perimeter_view,
+        expected_findings=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+        repaired_rules=frozenset(
+            {
+                "WL016_TEXT_DISPLAY_RISK",
+                "WL017_BORDER_EDGE_INCONSISTENCY",
+                "WL020_SAVED_VIEW_OFF_CONTENT",
+            }
+        ),
+    ),
+)
+
+
+def _rule_ids(scan: ScanResult) -> set[str]:
+    return {finding.rule_id for finding in scan.findings}
+
+
+def _selected_patch_ids(scan: ScanResult, rules: frozenset[str]) -> set[str]:
+    return {
+        patch_id
+        for finding in scan.findings
+        if finding.rule_id in rules
+        for patch_id in finding.patch_ids
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case.name)
+def test_layout_adversarial_workbook_repairs_are_composable(
+    tmp_path: Path,
+    case: LayoutCase,
+) -> None:
+    source = tmp_path / f"{case.name}.xlsx"
+    output = tmp_path / f"{case.name}-fixed.xlsx"
+    state = case.build(source)
+
+    before = scan_workbook(source)
+    assert case.expected_findings <= _rule_ids(before)
+    selected_ids = _selected_patch_ids(before, case.repaired_rules)
+    assert selected_ids
+    if "WL020_SAVED_VIEW_OFF_CONTENT" in case.remaining_rules:
+        view_findings = [
+            finding
+            for finding in before.findings
+            if finding.rule_id == "WL020_SAVED_VIEW_OFF_CONTENT"
+        ]
+        assert view_findings and all(not finding.patch_ids for finding in view_findings)
+
+    result = apply_patch_plan(
+        source,
+        build_patch_plan(before),
+        output,
+        selected_ids=selected_ids,
+        accept_layout_risk=True,
+    )
+
+    assert set(result.applied_patch_ids) >= selected_ids
+    after = scan_workbook(output)
+    after_layout_rules = _rule_ids(after) & LAYOUT_RULES
+    assert not (after_layout_rules & case.repaired_rules)
+    assert case.remaining_rules <= after_layout_rules
+    assert not _selected_patch_ids(after, case.repaired_rules)
+
+    if case.name in {"frozen-pane-mixed", "split-pane-conservative"}:
+        assert _pane_xml(output) == state["pane_xml"]
+    if case.name == "formatting-tail-and-view":
+        repaired = load_workbook(output, data_only=False, keep_links=False)
+        try:
+            worksheet = repaired["FormatTail"]
+            assert worksheet.calculate_dimension() == "A1:G20"
+            assert worksheet.row_dimensions[55].height == 22.0
+        finally:
+            repaired.close()
+    if case.name == "whitespace-tail-and-view":
+        repaired = load_workbook(output, data_only=False, keep_links=False)
+        try:
+            worksheet = repaired["WhitespaceTail"]
+            assert (9, 1) not in worksheet._cells
+            assert worksheet["A10"].value is None
+            assert worksheet["A10"].style_id == state["style_ids"]["A10"]
+            assert worksheet["A10"].font.italic is True
+            assert worksheet["A11"].value is None
+            assert worksheet["A11"].style_id == state["style_ids"]["A11"]
+            assert worksheet["A11"].alignment.horizontal == "right"
+            assert worksheet["A11"].protection.locked is False
+            assert worksheet["A11"].protection.hidden is True
+            assert all(worksheet.row_dimensions[row].height == 30.0 for row in range(9, 12))
+        finally:
+            repaired.close()
+    if case.name == "merged-title-perimeter-view":
+        repaired = load_workbook(output, data_only=False, keep_links=False)
+        try:
+            worksheet = repaired["MergedTitle"]
+            assert [str(cell_range) for cell_range in worksheet.merged_cells.ranges] == ["A1:I1"]
+        finally:
+            repaired.close()
+
+
+def test_adversarial_case_names_are_unique_and_count_is_bounded() -> None:
+    names = [case.name for case in CASES]
+    assert 5 <= len(names) <= 8
+    assert len(names) == len(set(names))

--- a/tests/integration/test_layout_ooxml_patch.py
+++ b/tests/integration/test_layout_ooxml_patch.py
@@ -1,0 +1,937 @@
+from __future__ import annotations
+
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from lxml import etree
+from openpyxl import Workbook, load_workbook
+from openpyxl.comments import Comment
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Protection, Side
+from openpyxl.worksheet.pagebreak import Break
+
+from workbooklens.exceptions import PatchValidationError, StalePlanError
+from workbooklens.layout import (
+    FormattingTail,
+    WhitespaceTail,
+    column_layout_fingerprint,
+    row_layout_fingerprint,
+    sheet_view_fingerprint,
+    tail_layout_fingerprint,
+    whitespace_tail_layout_fingerprint,
+)
+from workbooklens.models import (
+    PatchKind,
+    PatchOperation,
+    PatchPlan,
+    PatchPrecondition,
+    PatchRisk,
+)
+from workbooklens.repair.engine import apply_patch_plan
+from workbooklens.repair.ooxml_patch import patch_ooxml_package
+from workbooklens.repair.planning import build_patch_plan
+from workbooklens.scanner import scan_workbook
+from workbooklens.snapshot import cell_fingerprint
+from workbooklens.utils import sha256_file
+
+CUSTOM_XML = b'<audit xmlns="urn:workbooklens:test">preserve me</audit>'
+CUSTOM_BINARY = bytes(range(64))
+
+
+def _layout_patch(
+    worksheet: object,
+    *,
+    patch_id: str,
+    kind: PatchKind,
+    cell: str,
+    after: object,
+    source_cell: str | None = None,
+    layout_fingerprint: str | None = None,
+    atomic_group: str | None = None,
+) -> PatchOperation:
+    return PatchOperation(
+        id=patch_id,
+        kind=kind,
+        sheet="Sheet1",
+        cell=cell,
+        before=None,
+        after=after,
+        source_cell=source_cell,
+        confidence=0.99,
+        safe=False,
+        risk=PatchRisk.LAYOUT_REVIEW,
+        description=f"integration fixture for {kind.value}",
+        precondition=PatchPrecondition(
+            cell_fingerprint=cell_fingerprint(worksheet[cell]),  # type: ignore[index]
+            layout_fingerprint=layout_fingerprint,
+        ),
+        atomic_group=atomic_group,
+    )
+
+
+def _plan(source: Path, patches: list[PatchOperation]) -> PatchPlan:
+    return PatchPlan(
+        tool_version="2.1.0",
+        source_name=source.name,
+        source_sha256=sha256_file(source),
+        patches=patches,
+    )
+
+
+def _column_elements(path: Path) -> list[dict[str, str]]:
+    with zipfile.ZipFile(path) as archive:
+        root = etree.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+    return [
+        dict(element.attrib) for element in root.iter() if etree.QName(element).localname == "col"
+    ]
+
+
+def _rewrite_xml_part(
+    path: Path,
+    part: str,
+    mutate: Callable[[etree._Element], None],
+) -> None:
+    with zipfile.ZipFile(path, "r") as archive:
+        infos = archive.infolist()
+        data = {info.filename: archive.read(info.filename) for info in infos}
+    root = etree.fromstring(data[part])
+    mutate(root)
+    data[part] = etree.tostring(
+        root,
+        encoding="UTF-8",
+        xml_declaration=True,
+        standalone=True,
+    )
+    temporary = path.with_name(f"{path.stem}.rewrite{path.suffix}")
+    with zipfile.ZipFile(temporary, "w") as output:
+        for info in infos:
+            output.writestr(info, data[info.filename])
+    temporary.replace(path)
+
+
+def _formatting_tail_plan(source: Path, *, empty_rows: tuple[int, ...] = (60,)) -> PatchPlan:
+    workbook = load_workbook(source, data_only=False, keep_links=False)
+    worksheet = workbook["Sheet1"]
+    tail = FormattingTail(
+        cell_coordinates=("Z50",),
+        cell_ranges=("Z50",),
+        empty_rows=empty_rows,
+        row_ranges=tuple(str(row) for row in empty_rows),
+        styled_cell_count=1,
+        content_min_row=1,
+        content_min_column=1,
+        content_max_row=1,
+        content_max_column=1,
+        observed_max_row=max((50, *empty_rows)),
+        observed_max_column=26,
+    )
+    patch = _layout_patch(
+        worksheet,
+        patch_id="clear-tail",
+        kind=PatchKind.CLEAR_FORMATTING_TAIL,
+        cell="Z50",
+        after={
+            "cells": ["Z50"],
+            "empty_rows": list(empty_rows),
+            "expected_dimension": "A1:Z50",
+            "result_dimension": "A1",
+        },
+        layout_fingerprint=tail_layout_fingerprint(worksheet, tail),
+    )
+    workbook.close()
+    return _plan(source, [patch])
+
+
+def _make_formatting_tail_fixture(
+    path: Path,
+    *,
+    cross_sheet_formula: bool = False,
+    page_break: str | None = None,
+    create_empty_row: bool = True,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "content"
+    worksheet["Z50"].fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    if create_empty_row:
+        worksheet.row_dimensions[60].height = 22.0
+    if cross_sheet_formula:
+        other = workbook.create_sheet("Other")
+        other["A1"] = "='Sheet1'!Z50"
+    if page_break == "rowBreaks":
+        worksheet.row_breaks.append(Break(id=60))
+    elif page_break == "colBreaks":
+        worksheet.col_breaks.append(Break(id=26))
+    workbook.save(path)
+    workbook.close()
+
+
+def _make_layout_fixture(path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet.append(["Heading", "Long heading", 123, "Target", "Source"])
+    worksheet.append(["row two", "Second heading", 456, "x", "y"])
+
+    grouped = worksheet.column_dimensions["B"]
+    grouped.min = 2
+    grouped.max = 4
+    grouped.width = 9.0
+    grouped.bestFit = True
+    grouped.outlineLevel = 1
+    worksheet.row_dimensions[1].height = 15.0
+    worksheet.sheet_view.topLeftCell = "D4"
+    worksheet.sheet_view.zoomScale = 130
+
+    red_thin = Side(style="thin", color="FFFF0000")
+    worksheet["E1"].border = Border(left=red_thin)
+    worksheet["Z50"].fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    worksheet.row_dimensions[60].fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    workbook.save(path)
+    workbook.close()
+
+    with zipfile.ZipFile(path, "a", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("customXml/workbooklens-audit.xml", CUSTOM_XML)
+        archive.writestr("xl/media/unknown-extension.bin", CUSTOM_BINARY)
+
+
+def test_all_layout_patch_kinds_apply_and_preserve_package_details(tmp_path: Path) -> None:
+    source = tmp_path / "layout-source.xlsx"
+    output = tmp_path / "layout-fixed.xlsx"
+    _make_layout_fixture(source)
+
+    workbook = load_workbook(source, data_only=False, keep_links=False)
+    worksheet = workbook["Sheet1"]
+    tail = FormattingTail(
+        cell_coordinates=("Z50",),
+        cell_ranges=("Z50",),
+        empty_rows=(60,),
+        row_ranges=("60",),
+        styled_cell_count=1,
+        content_min_row=1,
+        content_min_column=1,
+        content_max_row=2,
+        content_max_column=5,
+        observed_max_row=60,
+        observed_max_column=26,
+    )
+    patches = [
+        _layout_patch(
+            worksheet,
+            patch_id="column-width",
+            kind=PatchKind.SET_COLUMN_WIDTH,
+            cell="C1",
+            after=22.5,
+            layout_fingerprint=column_layout_fingerprint(worksheet, 3),
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="row-height",
+            kind=PatchKind.SET_ROW_HEIGHT,
+            cell="A1",
+            after=30.0,
+            layout_fingerprint=row_layout_fingerprint(worksheet, 1),
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="wrap-one",
+            kind=PatchKind.SET_WRAP_TEXT,
+            cell="B1",
+            after=True,
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="wrap-two",
+            kind=PatchKind.SET_WRAP_TEXT,
+            cell="B2",
+            after=True,
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="shrink",
+            kind=PatchKind.SET_SHRINK_TO_FIT,
+            cell="A1",
+            after=True,
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="set-text",
+            kind=PatchKind.SET_TEXT,
+            cell="C1",
+            after="00123",
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="sheet-view",
+            kind=PatchKind.SET_SHEET_VIEW,
+            cell="A1",
+            after={"top_left_cell": "A1", "zoom_scale": 85},
+            layout_fingerprint=sheet_view_fingerprint(worksheet),
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="copy-border",
+            kind=PatchKind.COPY_BORDER,
+            cell="D1",
+            source_cell="E1",
+            after={"target_edge": "right", "source_edge": "left"},
+        ),
+        _layout_patch(
+            worksheet,
+            patch_id="clear-tail",
+            kind=PatchKind.CLEAR_FORMATTING_TAIL,
+            cell="Z50",
+            after={
+                "cells": ["Z50"],
+                "empty_rows": [60],
+                "expected_dimension": "A1:Z50",
+                "result_dimension": "A1:E2",
+            },
+            layout_fingerprint=tail_layout_fingerprint(worksheet, tail),
+        ),
+    ]
+    workbook.close()
+    plan = _plan(source, patches)
+
+    result, selected = patch_ooxml_package(
+        source,
+        plan,
+        output,
+        selected_ids={patch.id for patch in patches},
+        accept_layout_risk=True,
+        canonical_plan=plan,
+    )
+
+    assert {patch.kind for patch in selected} == {
+        PatchKind.SET_COLUMN_WIDTH,
+        PatchKind.SET_ROW_HEIGHT,
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_SHRINK_TO_FIT,
+        PatchKind.SET_TEXT,
+        PatchKind.SET_SHEET_VIEW,
+        PatchKind.COPY_BORDER,
+        PatchKind.CLEAR_FORMATTING_TAIL,
+    }
+    assert result.formula_changed
+    assert {change.part for change in result.changes} == {
+        "xl/styles.xml",
+        "xl/workbook.xml",
+        "xl/worksheets/sheet1.xml",
+    }
+
+    columns = _column_elements(output)
+    assert [(item["min"], item["max"]) for item in columns] == [
+        ("2", "2"),
+        ("3", "3"),
+        ("4", "4"),
+    ]
+    assert columns[1]["width"] == "22.5"
+    for key in ("bestFit", "outlineLevel"):
+        assert columns[0][key] == columns[2][key]
+
+    repaired = load_workbook(output, data_only=False, keep_links=False)
+    repaired_sheet = repaired["Sheet1"]
+    assert repaired_sheet.row_dimensions[1].height == 30.0
+    assert repaired_sheet["B1"].alignment.wrap_text
+    assert repaired_sheet["B2"].alignment.wrap_text
+    assert repaired_sheet["B1"].style_id == repaired_sheet["B2"].style_id
+    assert repaired_sheet["A1"].alignment.shrink_to_fit
+    assert repaired_sheet["C1"].value == "00123"
+    assert repaired_sheet["C1"].data_type == "s"
+    assert repaired_sheet["C1"].number_format == "@"
+    assert repaired_sheet.sheet_view.topLeftCell == "A1"
+    assert repaired_sheet.sheet_view.zoomScale == 85
+    assert repaired_sheet["D1"].border.right == repaired_sheet["E1"].border.left
+    assert (50, 26) not in repaired_sheet._cells
+    assert 60 not in repaired_sheet.row_dimensions
+    assert repaired_sheet.calculate_dimension() == "A1:E2"
+    repaired.close()
+
+    with zipfile.ZipFile(output) as archive:
+        assert archive.read("customXml/workbooklens-audit.xml") == CUSTOM_XML
+        assert archive.read("xl/media/unknown-extension.bin") == CUSTOM_BINARY
+        workbook_root = etree.fromstring(archive.read("xl/workbook.xml"))
+        calc = next(
+            (element for element in workbook_root if etree.QName(element).localname == "calcPr"),
+            None,
+        )
+        assert calc is not None
+        assert calc.get("calcMode") == "auto"
+        assert calc.get("fullCalcOnLoad") == "1"
+        assert calc.get("forceFullCalc") == "1"
+
+
+def test_layout_fingerprint_change_rejects_stale_plan(tmp_path: Path) -> None:
+    source = tmp_path / "fingerprint-source.xlsx"
+    output = tmp_path / "fingerprint-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["B1"] = "value"
+    worksheet.column_dimensions["B"].width = 10.0
+    workbook.save(source)
+    workbook.close()
+
+    workbook = load_workbook(source)
+    worksheet = workbook["Sheet1"]
+    patch = _layout_patch(
+        worksheet,
+        patch_id="column-width",
+        kind=PatchKind.SET_COLUMN_WIDTH,
+        cell="B1",
+        after=18.0,
+        layout_fingerprint=column_layout_fingerprint(worksheet, 2),
+    )
+    workbook.close()
+    plan = _plan(source, [patch])
+
+    workbook = load_workbook(source)
+    worksheet = workbook["Sheet1"]
+    worksheet.column_dimensions["B"].width = 11.0
+    workbook.save(source)
+    workbook.close()
+    plan.source_sha256 = sha256_file(source)
+
+    with pytest.raises(StalePlanError, match="Layout precondition failed"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+def test_zoom_only_sheet_view_patch_preserves_frozen_pane_xml(tmp_path: Path) -> None:
+    source = tmp_path / "frozen-view-source.xlsx"
+    output = tmp_path / "frozen-view-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "heading"
+    worksheet.freeze_panes = "B2"
+    worksheet.sheet_view.zoomScale = 115
+    workbook.save(source)
+    workbook.close()
+
+    with zipfile.ZipFile(source) as archive:
+        source_root = etree.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+    source_pane = next(
+        element for element in source_root.iter() if etree.QName(element).localname == "pane"
+    )
+    source_pane_xml = etree.tostring(source_pane)
+
+    workbook = load_workbook(source)
+    worksheet = workbook["Sheet1"]
+    patch = _layout_patch(
+        worksheet,
+        patch_id="frozen-zoom-only",
+        kind=PatchKind.SET_SHEET_VIEW,
+        cell="A1",
+        after={"zoom_scale": 65},
+        layout_fingerprint=sheet_view_fingerprint(worksheet),
+    )
+    workbook.close()
+
+    patch_ooxml_package(
+        source,
+        _plan(source, [patch]),
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+        canonical_plan=_plan(source, [patch]),
+    )
+
+    with zipfile.ZipFile(output) as archive:
+        output_root = etree.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+    output_pane = next(
+        element for element in output_root.iter() if etree.QName(element).localname == "pane"
+    )
+    assert etree.tostring(output_pane) == source_pane_xml
+    repaired = load_workbook(output)
+    repaired_sheet = repaired["Sheet1"]
+    assert repaired_sheet.freeze_panes == "B2"
+    assert repaired_sheet.sheet_view.zoomScale == 65
+    repaired.close()
+
+
+def test_sheet_view_origin_patch_refuses_a_frozen_pane(tmp_path: Path) -> None:
+    source = tmp_path / "frozen-origin-source.xlsx"
+    output = tmp_path / "frozen-origin-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "heading"
+    worksheet.freeze_panes = "A2"
+    workbook.save(source)
+    workbook.close()
+
+    workbook = load_workbook(source)
+    worksheet = workbook["Sheet1"]
+    patch = _layout_patch(
+        worksheet,
+        patch_id="frozen-origin",
+        kind=PatchKind.SET_SHEET_VIEW,
+        cell="A1",
+        after={"top_left_cell": "A1"},
+        layout_fingerprint=sheet_view_fingerprint(worksheet),
+    )
+    workbook.close()
+    plan = _plan(source, [patch])
+
+    with pytest.raises(PatchValidationError, match="origin repair refuses"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+def test_formatting_tail_rejects_commented_style_only_cell(tmp_path: Path) -> None:
+    source = tmp_path / "tail-source.xlsx"
+    output = tmp_path / "tail-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "content"
+    worksheet["Z50"].fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    worksheet["Z50"].comment = Comment("retain this note", "WorkbookLens test")
+    workbook.save(source)
+    workbook.close()
+
+    workbook = load_workbook(source)
+    worksheet = workbook["Sheet1"]
+    tail = FormattingTail(
+        cell_coordinates=("Z50",),
+        cell_ranges=("Z50",),
+        empty_rows=(),
+        row_ranges=(),
+        styled_cell_count=1,
+        content_min_row=1,
+        content_min_column=1,
+        content_max_row=1,
+        content_max_column=1,
+        observed_max_row=50,
+        observed_max_column=26,
+    )
+    patch = _layout_patch(
+        worksheet,
+        patch_id="clear-tail",
+        kind=PatchKind.CLEAR_FORMATTING_TAIL,
+        cell="Z50",
+        after={
+            "cells": ["Z50"],
+            "empty_rows": [],
+            "expected_dimension": "A1:Z50",
+            "result_dimension": "A1",
+        },
+        layout_fingerprint=tail_layout_fingerprint(worksheet, tail),
+    )
+    workbook.close()
+    plan = _plan(source, [patch])
+
+    with pytest.raises(PatchValidationError, match="comment or hyperlink"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+def test_formatting_tail_rejects_cross_sheet_formula_reference(tmp_path: Path) -> None:
+    source = tmp_path / "tail-cross-sheet-formula.xlsx"
+    output = tmp_path / "tail-cross-sheet-formula-output.xlsx"
+    _make_formatting_tail_fixture(source, cross_sheet_formula=True)
+    plan = _formatting_tail_plan(source)
+    patch = plan.patches[0]
+
+    with pytest.raises(PatchValidationError, match="referenced by a worksheet formula"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("collection", ["rowBreaks", "colBreaks"])
+def test_formatting_tail_rejects_intersecting_page_break(
+    tmp_path: Path,
+    collection: str,
+) -> None:
+    source = tmp_path / f"tail-{collection}.xlsx"
+    output = tmp_path / f"tail-{collection}-output.xlsx"
+    _make_formatting_tail_fixture(source, page_break=collection)
+    plan = _formatting_tail_plan(source)
+    patch = plan.patches[0]
+
+    with pytest.raises(PatchValidationError, match=rf"intersects {collection}"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+def test_formatting_tail_rejects_namespaced_empty_row_attribute(tmp_path: Path) -> None:
+    source = tmp_path / "tail-namespaced-row-attribute.xlsx"
+    output = tmp_path / "tail-namespaced-row-attribute-output.xlsx"
+    _make_formatting_tail_fixture(source)
+
+    def add_namespaced_empty_row(root: etree._Element) -> None:
+        row = next(
+            element
+            for element in root.iter()
+            if etree.QName(element).localname == "row" and element.get("r") == "60"
+        )
+        row.set("{urn:workbooklens:test}futureFlag", "retain")
+
+    _rewrite_xml_part(source, "xl/worksheets/sheet1.xml", add_namespaced_empty_row)
+    plan = _formatting_tail_plan(source)
+    patch = plan.patches[0]
+
+    with pytest.raises(PatchValidationError, match="row 60 has unsupported attributes"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+def test_formatting_tail_rejects_custom_height_empty_row(tmp_path: Path) -> None:
+    source = tmp_path / "tail-custom-height.xlsx"
+    output = tmp_path / "tail-custom-height-output.xlsx"
+    _make_formatting_tail_fixture(source)
+    plan = _formatting_tail_plan(source)
+    patch = plan.patches[0]
+
+    with pytest.raises(PatchValidationError, match="custom-height rows"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()
+
+
+def test_formatting_tail_cleanup_preserves_custom_height_and_single_cell_dimension(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "tail-with-custom-height.xlsx"
+    output = tmp_path / "tail-with-custom-height-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "content"
+    fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    for row in range(50, 54):
+        for column in range(16, 20):
+            worksheet.cell(row, column).fill = fill
+    worksheet.row_dimensions[55].height = 22.0
+    workbook.save(source)
+    workbook.close()
+
+    def include_custom_height_row_in_declared_dimension(root: etree._Element) -> None:
+        dimension = next(
+            element for element in root if etree.QName(element).localname == "dimension"
+        )
+        dimension.set("ref", "A1:S55")
+
+    _rewrite_xml_part(
+        source,
+        "xl/worksheets/sheet1.xml",
+        include_custom_height_row_in_declared_dimension,
+    )
+
+    scan = scan_workbook(source)
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL)
+    assert patch.after["empty_rows"] == []
+    assert patch.after["result_dimension"] == "A1"
+
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids=[patch.id],
+        accept_layout_risk=True,
+    )
+
+    repaired = load_workbook(output, data_only=False, keep_links=False)
+    repaired_sheet = repaired["Sheet1"]
+    assert repaired_sheet.row_dimensions[55].height == 22.0
+    assert repaired_sheet.calculate_dimension() == "A1:A1"
+    repaired.close()
+    with zipfile.ZipFile(output) as archive:
+        root = etree.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+    dimension = next(element for element in root if etree.QName(element).localname == "dimension")
+    assert dimension.get("ref") == "A1"
+
+
+def test_formatting_tail_cleanup_preserves_large_merged_dimension(tmp_path: Path) -> None:
+    source = tmp_path / "tail-with-large-merge.xlsx"
+    output = tmp_path / "tail-with-large-merge-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "Merged report title"
+    worksheet.merge_cells("A1:H20")
+    fill = PatternFill(fill_type="solid", fgColor="FFFFFF00")
+    for row in range(50, 54):
+        for column in range(16, 20):
+            worksheet.cell(row, column).fill = fill
+    workbook.save(source)
+    workbook.close()
+
+    scan = scan_workbook(source)
+    findings = [
+        finding for finding in scan.findings if finding.rule_id == "WL018_USED_RANGE_INFLATION"
+    ]
+    assert len(findings) == 1
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL)
+    assert patch.after["result_dimension"] == "A1:H20"
+
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids=[patch.id],
+        accept_layout_risk=True,
+    )
+
+    repaired = load_workbook(output, data_only=False, keep_links=False)
+    repaired_sheet = repaired["Sheet1"]
+    assert repaired_sheet.calculate_dimension() == "A1:H20"
+    assert [str(cell_range) for cell_range in repaired_sheet.merged_cells.ranges] == ["A1:H20"]
+    repaired.close()
+
+
+def test_whitespace_tail_cleanup_preserves_nondefault_cell_semantics(tmp_path: Path) -> None:
+    source = tmp_path / "whitespace-style-source.xlsx"
+    output = tmp_path / "whitespace-style-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "content"
+    worksheet["A9"] = " "
+    worksheet["A10"] = " "
+    worksheet["A10"].font = Font(bold=True, name="Aptos")
+    worksheet["A11"] = " "
+    worksheet["A11"].alignment = Alignment(horizontal="center")
+    worksheet["A11"].protection = Protection(locked=False, hidden=True)
+    workbook.save(source)
+    workbook.close()
+
+    workbook = load_workbook(source, data_only=False, keep_links=False)
+    worksheet = workbook["Sheet1"]
+    preserve_style_ids = {
+        "A10": worksheet["A10"].style_id,
+        "A11": worksheet["A11"].style_id,
+    }
+    tail = WhitespaceTail(
+        cell_coordinates=("A9", "A10", "A11"),
+        cell_ranges=("A9:A11",),
+        row_ranges=(),
+        content_min_row=1,
+        content_min_column=1,
+        content_max_row=1,
+        content_max_column=1,
+        observed_dimension="A1:A11",
+        result_dimension="A1:A11",
+        preserve_style_ids=tuple(sorted(preserve_style_ids.items())),
+    )
+    patch = _layout_patch(
+        worksheet,
+        patch_id="clear-whitespace-preserve-styles",
+        kind=PatchKind.REMOVE_WHITESPACE_TAIL_CELLS,
+        cell="A1",
+        after={
+            "cells": ["A9", "A10", "A11"],
+            "expected_dimension": "A1:A11",
+            "preserve_style_ids": preserve_style_ids,
+            "result_dimension": "A1:A11",
+            "preserve_row_dimensions": True,
+        },
+        layout_fingerprint=whitespace_tail_layout_fingerprint(worksheet, tail),
+    )
+    workbook.close()
+    plan = _plan(source, [patch])
+
+    patch_ooxml_package(
+        source,
+        plan,
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+        canonical_plan=plan,
+    )
+
+    repaired = load_workbook(output, data_only=False, keep_links=False)
+    repaired_sheet = repaired["Sheet1"]
+    assert (9, 1) not in repaired_sheet._cells
+    assert repaired_sheet["A10"].value is None
+    assert repaired_sheet["A10"].style_id == preserve_style_ids["A10"]
+    assert repaired_sheet["A10"].font.bold is True
+    assert repaired_sheet["A11"].value is None
+    assert repaired_sheet["A11"].style_id == preserve_style_ids["A11"]
+    assert repaired_sheet["A11"].alignment.horizontal == "center"
+    assert repaired_sheet["A11"].protection.locked is False
+    assert repaired_sheet["A11"].protection.hidden is True
+    assert repaired_sheet.calculate_dimension() == "A1:A11"
+    repaired.close()
+
+    with zipfile.ZipFile(output) as archive:
+        root = etree.fromstring(archive.read("xl/worksheets/sheet1.xml"))
+    cells = {
+        element.get("r"): element
+        for element in root.iter()
+        if etree.QName(element).localname == "c"
+    }
+    assert "A9" not in cells
+    for coordinate in ("A10", "A11"):
+        assert cells[coordinate].get("s") == str(preserve_style_ids[coordinate])
+        assert cells[coordinate].get("t") is None
+        assert len(cells[coordinate]) == 0
+
+
+def test_scanned_whitespace_tail_preserves_style_semantics_end_to_end(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "whitespace-style-scan-source.xlsx"
+    output = tmp_path / "whitespace-style-scan-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    worksheet["A9"] = " "
+    worksheet["A10"] = " "
+    worksheet["A10"].font = Font(italic=True)
+    worksheet["A11"] = " "
+    worksheet["A11"].alignment = Alignment(horizontal="right")
+    worksheet["A11"].protection = Protection(locked=False)
+    workbook.save(source)
+    workbook.close()
+
+    scan = scan_workbook(source)
+    patch = next(
+        patch for patch in scan.patches if patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS
+    )
+    preserved_style_ids = patch.after["preserve_style_ids"]
+    assert set(preserved_style_ids) == {"A10", "A11"}
+    assert patch.after["expected_dimension"] == "A1:A11"
+    assert patch.after["result_dimension"] == "A1:A11"
+
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+    )
+
+    repaired = load_workbook(output, data_only=False, keep_links=False)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    assert (9, 1) not in repaired_sheet._cells
+    assert repaired_sheet["A10"].value is None
+    assert repaired_sheet["A10"].font.italic is True
+    assert repaired_sheet["A11"].value is None
+    assert repaired_sheet["A11"].alignment.horizontal == "right"
+    assert repaired_sheet["A11"].protection.locked is False
+    assert repaired_sheet.calculate_dimension() == "A1:A11"
+    repaired.close()
+    assert not any(
+        finding.rule_id == "WL021_WHITESPACE_ONLY_TAIL"
+        for finding in scan_workbook(output).findings
+    )
+
+
+def test_whitespace_tail_cleanup_rejects_unrecognized_nondefault_style(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "whitespace-unrecognized-style.xlsx"
+    output = tmp_path / "whitespace-unrecognized-style-output.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "content"
+    for row in range(9, 12):
+        worksheet.cell(row, 1, " ").protection = Protection(locked=False)
+    workbook.save(source)
+    workbook.close()
+
+    workbook = load_workbook(source, data_only=False, keep_links=False)
+    worksheet = workbook["Sheet1"]
+    tail = WhitespaceTail(
+        cell_coordinates=("A9", "A10", "A11"),
+        cell_ranges=("A9:A11",),
+        row_ranges=(),
+        content_min_row=1,
+        content_min_column=1,
+        content_max_row=1,
+        content_max_column=1,
+        observed_dimension="A1:A11",
+        result_dimension="A1",
+    )
+    patch = _layout_patch(
+        worksheet,
+        patch_id="unsafe-whitespace-style-removal",
+        kind=PatchKind.REMOVE_WHITESPACE_TAIL_CELLS,
+        cell="A1",
+        after={
+            "cells": ["A9", "A10", "A11"],
+            "expected_dimension": "A1:A11",
+            "preserve_style_ids": {},
+            "result_dimension": "A1",
+            "preserve_row_dimensions": True,
+        },
+        layout_fingerprint=whitespace_tail_layout_fingerprint(worksheet, tail),
+    )
+    workbook.close()
+    plan = _plan(source, [patch])
+
+    with pytest.raises(PatchValidationError, match="unauthorized non-default style"):
+        patch_ooxml_package(
+            source,
+            plan,
+            output,
+            selected_ids={patch.id},
+            accept_layout_risk=True,
+            canonical_plan=plan,
+        )
+    assert not output.exists()

--- a/tests/integration/test_repair_workflow.py
+++ b/tests/integration/test_repair_workflow.py
@@ -33,11 +33,13 @@ def test_demo_applies_four_safe_patch_types_and_reopens(completed_demo: DemoOutp
     plan = PatchPlan.model_validate_json(completed_demo.repair_plan.read_text(encoding="utf-8"))
     report_path = completed_demo.directory / "apply-report.json"
     result = PatchResult.model_validate_json(report_path.read_text(encoding="utf-8"))
-    assert len(plan.patches) == 4
+    safe_patch_ids = {patch.id for patch in plan.patches if patch.safe_only_eligible}
+    assert len(safe_patch_ids) == 4
+    assert len(plan.patches) >= len(safe_patch_ids)
     assert plan.findings
     assert {finding.id for finding in plan.findings} == set(plan.finding_ids)
     assert all(finding.evidence.summary for finding in plan.findings)
-    assert len(result.applied_patch_ids) == 4
+    assert set(result.applied_patch_ids) == safe_patch_ids
     assert result.source_sha256 == sha256_file(completed_demo.before_workbook)
     assert result.output_sha256 == sha256_file(completed_demo.after_workbook)
     workbook = load_workbook(completed_demo.after_workbook, read_only=True, data_only=False)

--- a/tests/integration/test_web.py
+++ b/tests/integration/test_web.py
@@ -1,26 +1,123 @@
 from __future__ import annotations
 
+import asyncio
 import re
 from pathlib import Path
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import Response
+from starlette import formparsers
+from starlette.types import Message, Scope
 
 from workbooklens.demo.workflow import generate_demo_workbook
 from workbooklens.web import create_app
+from workbooklens.web.app import CSRF_COOKIE_NAME, MAX_MULTIPART_OVERHEAD_BYTES
+
+
+def _csrf_token(html: str) -> str:
+    match = re.search(r'name="csrf_token" value="([A-Za-z0-9_-]+)"', html)
+    assert match
+    token = match.group(1)
+    assert len(token) >= 43
+    return token
+
+
+def _client(app: FastAPI) -> TestClient:
+    return TestClient(app, base_url="http://127.0.0.1")
+
+
+def _run_asgi_post(
+    app: FastAPI,
+    headers: list[tuple[bytes, bytes]],
+    chunks: list[bytes],
+) -> tuple[list[Message], int]:
+    async def run_request() -> tuple[list[Message], int]:
+        messages: list[Message] = []
+        receive_calls = 0
+
+        async def receive() -> Message:
+            nonlocal receive_calls
+            if receive_calls >= len(chunks):
+                return {"type": "http.disconnect"}
+            index = receive_calls
+            receive_calls += 1
+            return {
+                "type": "http.request",
+                "body": chunks[index],
+                "more_body": index < len(chunks) - 1,
+            }
+
+        async def send(message: Message) -> None:
+            messages.append(message)
+
+        scope: Scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/scan",
+            "raw_path": b"/scan",
+            "query_string": b"",
+            "root_path": "",
+            "headers": headers,
+            "client": ("127.0.0.1", 54321),
+            "server": ("127.0.0.1", 80),
+            "app": app,
+        }
+        await app(scope, receive, send)
+        return messages, receive_calls
+
+    return asyncio.run(run_request())
+
+
+def _response_status(messages: list[Message]) -> int:
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    return start["status"]
+
+
+def _response_headers(messages: list[Message]) -> dict[bytes, bytes]:
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    return dict(start["headers"])
+
+
+def _assert_security_headers(response: Response) -> None:
+    headers = response.headers
+    assert headers["cache-control"] == "no-store"
+    assert headers["x-content-type-options"] == "nosniff"
+    assert headers["x-frame-options"] == "DENY"
+    assert headers["referrer-policy"] == "no-referrer"
+    assert headers["cross-origin-opener-policy"] == "same-origin"
+    assert headers["cross-origin-resource-policy"] == "same-origin"
+    policy = headers["content-security-policy"]
+    assert "default-src 'none'" in policy
+    assert "style-src 'unsafe-inline'" in policy
+    assert "script-src 'unsafe-inline'" in policy
+    assert "form-action 'self'" in policy
+    assert "frame-ancestors 'none'" in policy
 
 
 def test_local_web_scan_apply_and_download_workflow(tmp_path: Path) -> None:
     workbook = tmp_path / "demo.xlsx"
     generate_demo_workbook(workbook)
     app = create_app(max_file_bytes=5 * 1024 * 1024)
-    with TestClient(app) as client:
-        assert client.get("/health").json() == {"status": "ok"}
+    with _client(app) as client:
+        health = client.get("/health")
+        assert health.json() == {"status": "ok"}
+        _assert_security_headers(health)
         home = client.get("/")
         assert home.status_code == 200
-        assert "Files remain in a temporary local directory" in home.text
+        assert "removed on normal server shutdown" in home.text
+        token = _csrf_token(home.text)
+        assert client.cookies.get(CSRF_COOKIE_NAME) == token
+        set_cookie = home.headers["set-cookie"].lower()
+        assert "httponly" in set_cookie
+        assert "samesite=strict" in set_cookie
         with workbook.open("rb") as handle:
             response = client.post(
                 "/scan",
+                data={"csrf_token": token},
                 files={
                     "workbook": (
                         "demo.xlsx",
@@ -33,15 +130,20 @@ def test_local_web_scan_apply_and_download_workflow(tmp_path: Path) -> None:
         session_match = re.search(r"/sessions/([^/]+)/apply", response.text)
         assert session_match
         session_id = session_match.group(1)
-        patch_ids = re.findall(r'name="patch_id" value="([^"]+)"', response.text)
+        result_token = _csrf_token(response.text)
+        patch_ids = re.findall(r'name="patch_id" value="([^"]+)" data-risk="safe"', response.text)
         assert len(patch_ids) == 4
+        assert 'data-risk="layout_review"' in response.text
         report = client.get(f"/sessions/{session_id}/report")
         assert report.status_code == 200
         assert report.headers["content-disposition"].startswith("inline")
+        _assert_security_headers(report)
         assert client.get(f"/sessions/{session_id}/plan").status_code == 200
+        rejected_apply = client.post(f"/sessions/{session_id}/apply", data={"patch_id": patch_ids})
+        assert rejected_apply.status_code == 403
         applied = client.post(
             f"/sessions/{session_id}/apply",
-            data={"patch_id": patch_ids},
+            data={"csrf_token": result_token, "patch_id": patch_ids},
         )
         assert applied.status_code == 200, applied.text
         assert "Validated copy created" in applied.text
@@ -56,14 +158,17 @@ def test_local_web_scan_apply_and_download_workflow(tmp_path: Path) -> None:
 
 def test_web_rejects_wrong_extension_and_oversized_upload() -> None:
     app = create_app(max_file_bytes=10)
-    with TestClient(app) as client:
+    with _client(app) as client:
+        token = _csrf_token(client.get("/").text)
         wrong = client.post(
             "/scan",
+            data={"csrf_token": token},
             files={"workbook": ("notes.txt", b"hello", "text/plain")},
         )
         assert wrong.status_code == 400
         oversized = client.post(
             "/scan",
+            data={"csrf_token": token},
             files={"workbook": ("book.xlsx", b"x" * 11, "application/octet-stream")},
         )
         assert oversized.status_code == 413
@@ -73,15 +178,13 @@ def test_xlsm_web_scan_does_not_offer_repairs(tmp_path: Path) -> None:
     xlsx = tmp_path / "demo.xlsx"
     generate_demo_workbook(xlsx)
     app = create_app(max_file_bytes=5 * 1024 * 1024)
-    with TestClient(app) as client, xlsx.open("rb") as handle:
+    with _client(app) as client, xlsx.open("rb") as handle:
+        token = _csrf_token(client.get("/").text)
         response = client.post(
             "/scan",
+            data={"csrf_token": token},
             files={
-                "workbook": (
-                    "demo.xlsm",
-                    handle,
-                    "application/vnd.ms-excel.sheet.macroEnabled.12",
-                )
+                "workbook": ("demo.xlsm", handle, "application/vnd.ms-excel.sheet.macroEnabled.12")
             },
         )
     assert response.status_code == 200
@@ -91,15 +194,179 @@ def test_xlsm_web_scan_does_not_offer_repairs(tmp_path: Path) -> None:
 
 def test_web_errors_are_recoverable_html_pages() -> None:
     app = create_app(max_file_bytes=10)
-    with TestClient(app) as client:
+    with _client(app) as client:
+        token = _csrf_token(client.get("/").text)
         response = client.post(
             "/scan",
+            data={"csrf_token": token},
             files={"workbook": ("notes.txt", b"hello", "text/plain")},
         )
     assert response.status_code == 400
     assert response.headers["content-type"].startswith("text/html")
     assert "could not continue" in response.text
     assert "source workbook was not modified" in response.text
+
+
+def test_web_accepts_only_exact_loopback_host_headers() -> None:
+    app = create_app()
+    with _client(app) as client:
+        for host in ("localhost", "localhost:8123", "127.0.0.1", "127.0.0.1:65535"):
+            response = client.get("/health", headers={"host": host})
+            assert response.status_code == 200
+            _assert_security_headers(response)
+        for host in (
+            "testserver",
+            "localhost.example",
+            "127.0.0.2",
+            "localhost:0",
+            "localhost:65536",
+            "localhost:not-a-port",
+        ):
+            response = client.get("/health", headers={"host": host})
+            assert response.status_code == 400
+            assert response.text == "Invalid Host header"
+            _assert_security_headers(response)
+
+
+def test_web_rejects_missing_invalid_and_cross_origin_csrf() -> None:
+    app = create_app()
+    with _client(app) as client:
+        home = client.get("/")
+        token = _csrf_token(home.text)
+        for data, headers in (
+            ({}, {}),
+            ({"csrf_token": "not-the-server-token"}, {}),
+            ({"csrf_token": token}, {"origin": "https://example.com"}),
+            ({"csrf_token": token}, {"referer": "http://localhost.example/form"}),
+        ):
+            response = client.post(
+                "/scan",
+                data=data,
+                headers=headers,
+                files={"workbook": ("book.xlsx", b"not parsed", "application/octet-stream")},
+            )
+            assert response.status_code == 403
+            _assert_security_headers(response)
+        same_origin = client.post(
+            "/scan",
+            data={"csrf_token": token},
+            headers={"origin": "http://127.0.0.1", "referer": "http://127.0.0.1/"},
+            files={"workbook": ("notes.txt", b"hello", "text/plain")},
+        )
+        assert same_origin.status_code == 400
+        assert "Upload must be .xlsx or .xlsm" in same_origin.text
+
+
+def test_early_guard_rejects_before_multipart_tempfile(
+    monkeypatch,
+) -> None:
+    app = create_app(max_file_bytes=1024)
+    with _client(app) as client:
+        home = client.get("/")
+        token = _csrf_token(home.text)
+
+        def unexpected_spool(*_args, **_kwargs):
+            raise AssertionError("multipart parser created a temporary file before early rejection")
+
+        monkeypatch.setattr(formparsers, "SpooledTemporaryFile", unexpected_spool)
+
+        cross_site = client.post(
+            "/scan",
+            data={"csrf_token": token},
+            headers={"origin": "https://example.com"},
+            files={"workbook": ("book.xlsx", b"small", "application/octet-stream")},
+        )
+        assert cross_site.status_code == 403
+
+        oversized = client.post(
+            "/scan",
+            data={"csrf_token": token},
+            files={
+                "workbook": (
+                    "book.xlsx",
+                    b"x" * (1024 + MAX_MULTIPART_OVERHEAD_BYTES + 1024),
+                    "application/octet-stream",
+                )
+            },
+        )
+        assert oversized.status_code == 413
+
+        client.cookies.clear()
+        missing_cookie = client.post(
+            "/scan",
+            data={"csrf_token": token},
+            files={"workbook": ("book.xlsx", b"small", "application/octet-stream")},
+        )
+        assert missing_cookie.status_code == 403
+
+
+def test_declared_oversized_body_is_rejected_without_receive() -> None:
+    app = create_app(max_file_bytes=1024)
+    token = str(app.state.csrf_token)
+    messages, receive_calls = _run_asgi_post(
+        app,
+        [
+            (b"host", b"127.0.0.1"),
+            (b"content-type", b"multipart/form-data; boundary=guard"),
+            (b"content-length", b"999999"),
+            (b"cookie", f"{CSRF_COOKIE_NAME}={token}".encode()),
+        ],
+        [b"must not be consumed"],
+    )
+
+    assert _response_status(messages) == 413
+    assert receive_calls == 0
+
+    missing_length_messages, missing_length_calls = _run_asgi_post(
+        app,
+        [
+            (b"host", b"127.0.0.1"),
+            (b"content-type", b"multipart/form-data; boundary=guard"),
+            (b"cookie", f"{CSRF_COOKIE_NAME}={token}".encode()),
+        ],
+        [b"must not be consumed"],
+    )
+    assert _response_status(missing_length_messages) == 411
+    assert missing_length_calls == 0
+
+
+def test_actual_streaming_body_limit_stops_before_full_consumption() -> None:
+    app = create_app(max_file_bytes=1)
+    token = str(app.state.csrf_token)
+    prefix = f"csrf_token={token}&padding=".encode()
+    chunks = [prefix + b"x" * 8192, *([b"x" * 8192] * 7)]
+    messages, receive_calls = _run_asgi_post(
+        app,
+        [
+            (b"host", b"127.0.0.1"),
+            (b"content-type", b"application/x-www-form-urlencoded"),
+            (b"cookie", f"{CSRF_COOKIE_NAME}={token}".encode()),
+        ],
+        chunks,
+    )
+
+    assert _response_status(messages) == 413
+    headers = _response_headers(messages)
+    assert headers[b"cache-control"] == b"no-store"
+    assert headers[b"x-content-type-options"] == b"nosniff"
+    assert receive_calls == 2
+    assert sum(len(chunk) for chunk in chunks[receive_calls:]) == 49_152
+
+
+def test_security_headers_apply_to_html_json_and_errors() -> None:
+    app = create_app()
+    with _client(app) as client:
+        responses = [
+            client.get("/"),
+            client.get("/health"),
+            client.get("/missing"),
+            client.post(
+                "/scan",
+                files={"workbook": ("book.xlsx", b"not parsed", "application/octet-stream")},
+            ),
+        ]
+    for response in responses:
+        _assert_security_headers(response)
 
 
 def test_serve_command_hardcodes_loopback_binding() -> None:

--- a/tests/security/test_package_safety.py
+++ b/tests/security/test_package_safety.py
@@ -17,6 +17,10 @@ from workbooklens.ooxml.safety import (
 from workbooklens.worksheet_state import hidden_column_labels
 
 CONTENT_TYPES = b'<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>'
+XLSX_WORKBOOK_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
+)
+XLSM_WORKBOOK_CONTENT_TYPE = "application/vnd.ms-excel.sheet.macroEnabled.main+xml"
 WORKBOOK = b'<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>'
 ROOT_RELS = b"""<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
 <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
@@ -26,13 +30,23 @@ ROOT_RELS = b"""<Relationships xmlns="http://schemas.openxmlformats.org/package/
 def _minimal_package(
     path: Path,
     extras: list[tuple[str | zipfile.ZipInfo, bytes]] | None = None,
+    *,
+    content_types: bytes = CONTENT_TYPES,
 ) -> None:
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-        archive.writestr("[Content_Types].xml", CONTENT_TYPES)
+        archive.writestr("[Content_Types].xml", content_types)
         archive.writestr("_rels/.rels", ROOT_RELS)
         archive.writestr("xl/workbook.xml", WORKBOOK)
         for name, data in extras or []:
             archive.writestr(name, data)
+
+
+def _content_types(*declarations: str) -> bytes:
+    body = "".join(declarations)
+    return (
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+        f"{body}</Types>"
+    ).encode()
 
 
 def test_valid_openpyxl_package_passes(tmp_path: Path) -> None:
@@ -44,6 +58,106 @@ def test_valid_openpyxl_package_passes(tmp_path: Path) -> None:
     inspection = inspect_package(path)
     assert inspection.format == "xlsx"
     assert "xl/workbook.xml" in inspection.part_names
+
+
+def test_default_only_xlsx_content_type_is_repairable(tmp_path: Path) -> None:
+    path = tmp_path / "default-only.xlsx"
+    _minimal_package(
+        path,
+        content_types=_content_types(
+            f'<Default Extension=".XML" ContentType="{XLSX_WORKBOOK_CONTENT_TYPE.upper()}"/>'
+        ),
+    )
+
+    inspection = inspect_package(path)
+
+    assert inspection.content_format == "xlsx"
+    assert inspection.has_vba is False
+    assert inspection.format_mismatch is False
+    assert inspection.repairable is True
+    assert inspection.format == "xlsx"
+
+
+def test_default_only_macro_content_type_is_read_only(tmp_path: Path) -> None:
+    path = tmp_path / "default-macro.xlsx"
+    _minimal_package(
+        path,
+        content_types=_content_types(
+            f'<Default Extension="xml" ContentType="{XLSM_WORKBOOK_CONTENT_TYPE}"/>'
+        ),
+    )
+
+    inspection = inspect_package(path)
+
+    assert inspection.content_format == "xlsm"
+    assert inspection.has_vba is True
+    assert inspection.format_mismatch is True
+    assert inspection.repairable is False
+    assert inspection.format == "xlsm"
+
+
+def test_default_only_extension_mismatch_is_read_only(tmp_path: Path) -> None:
+    path = tmp_path / "default-xlsx.xlsm"
+    _minimal_package(
+        path,
+        content_types=_content_types(
+            f'<Default Extension="xml" ContentType="{XLSX_WORKBOOK_CONTENT_TYPE}"/>'
+        ),
+    )
+
+    inspection = inspect_package(path)
+
+    assert inspection.content_format == "xlsx"
+    assert inspection.has_vba is False
+    assert inspection.format_mismatch is True
+    assert inspection.repairable is False
+    assert inspection.format == "xlsm"
+
+
+def test_override_precedence_does_not_hide_macro_markers(tmp_path: Path) -> None:
+    path = tmp_path / "macro-marker.xlsx"
+    _minimal_package(
+        path,
+        content_types=_content_types(
+            f'<Default Extension="xml" ContentType="{XLSM_WORKBOOK_CONTENT_TYPE}"/>',
+            f'<Override PartName="/xl/workbook.xml" ContentType="{XLSX_WORKBOOK_CONTENT_TYPE}"/>',
+        ),
+    )
+
+    inspection = inspect_package(path)
+
+    assert inspection.content_format == "xlsm"
+    assert inspection.has_vba is True
+    assert inspection.format_mismatch is True
+    assert inspection.repairable is False
+
+
+def test_conflicting_override_content_types_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "conflicting-override.xlsx"
+    _minimal_package(
+        path,
+        content_types=_content_types(
+            f'<Override PartName="/xl/workbook.xml" ContentType="{XLSX_WORKBOOK_CONTENT_TYPE}"/>',
+            f'<Override PartName="xl/workbook.xml" ContentType="{XLSM_WORKBOOK_CONTENT_TYPE}"/>',
+        ),
+    )
+
+    with pytest.raises(UnsafeWorkbookError, match="conflicting Override"):
+        inspect_package(path)
+
+
+def test_conflicting_default_content_types_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "conflicting-default.xlsx"
+    _minimal_package(
+        path,
+        content_types=_content_types(
+            f'<Default Extension="XML" ContentType="{XLSX_WORKBOOK_CONTENT_TYPE}"/>',
+            f'<Default Extension=".xml" ContentType="{XLSM_WORKBOOK_CONTENT_TYPE}"/>',
+        ),
+    )
+
+    with pytest.raises(UnsafeWorkbookError, match="conflicting Default"):
+        inspect_package(path)
 
 
 @pytest.mark.parametrize("name", ["../escape.xml", "/absolute.xml"])

--- a/tests/security/test_v2_repair_integrity.py
+++ b/tests/security/test_v2_repair_integrity.py
@@ -31,6 +31,7 @@ RELATIONSHIPS_NS = "http://schemas.openxmlformats.org/package/2006/relationships
 XLSM_WORKBOOK_CONTENT_TYPE = "application/vnd.ms-excel.sheet.macroEnabled.main+xml"
 VBA_CONTENT_TYPE = "application/vnd.ms-office.vbaProject"
 VBA_RELATIONSHIP_TYPE = "http://schemas.microsoft.com/office/2006/relationships/vbaProject"
+SPREADSHEET_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 SCAN_CONFIG = {"keys": [{"sheet": "Sales", "range": "A2:A22", "ignore_blank": True}]}
 
 
@@ -86,7 +87,7 @@ def _mutate_cell(patch: PatchOperation) -> None:
     ("field", "mutate", "expected_error"),
     [
         ("after", _mutate_after, PatchValidationError),
-        ("safe", _mutate_safe, PatchValidationError),
+        ("safe", _mutate_safe, UsageError),
         ("confidence", _mutate_confidence, PatchValidationError),
         ("kind", _mutate_kind, PatchValidationError),
         ("source_cell", _mutate_source_cell, PatchValidationError),
@@ -306,3 +307,80 @@ def test_low_level_style_copy_rejects_semantic_mismatch(
 
     with pytest.raises(PatchValidationError, match=expected_message):
         ooxml_patch._verify_preconditions(source, plan, [patch], None)
+
+
+def _append_duplicate_cell_xf(path: Path, style_id: int) -> int:
+    rewritten = path.with_name(f"{path.stem}-duplicate-xf{path.suffix}")
+    with zipfile.ZipFile(path, "r") as source, zipfile.ZipFile(rewritten, "w") as output:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename == "xl/styles.xml":
+                root = etree.fromstring(data)
+                cell_xfs = root.find(f"{{{SPREADSHEET_NS}}}cellXfs")
+                assert cell_xfs is not None
+                assert 0 <= style_id < len(cell_xfs)
+                duplicate_id = len(cell_xfs)
+                cell_xfs.append(copy.deepcopy(cell_xfs[style_id]))
+                cell_xfs.set("count", str(len(cell_xfs)))
+                data = etree.tostring(
+                    root,
+                    xml_declaration=True,
+                    encoding="UTF-8",
+                    standalone=True,
+                )
+            output.writestr(info, data)
+    rewritten.replace(path)
+    return duplicate_id
+
+
+def test_copy_style_validation_uses_source_style_not_numeric_style_id(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "duplicate-cell-xfs.xlsx"
+    generate_demo_workbook(source)
+    plan = _plan(source)
+    patch = next(item for item in plan.patches if item.kind == PatchKind.COPY_STYLE)
+    assert patch.source_cell is not None
+
+    workbook = load_workbook(source)
+    source_style_id = workbook[patch.sheet][patch.source_cell].style_id
+    workbook.close()
+    assert patch.after == source_style_id
+    duplicate_style_id = _append_duplicate_cell_xf(source, source_style_id)
+    assert duplicate_style_id != source_style_id
+
+    plan.source_sha256 = sha256_file(source)
+    output = tmp_path / "duplicate-cell-xfs-fixed.xlsx"
+    ooxml_patch.patch_ooxml_package(
+        source,
+        plan,
+        output,
+        selected_ids={patch.id},
+        canonical_plan=plan,
+    )
+
+    workbook = load_workbook(output)
+    try:
+        worksheet = workbook[patch.sheet]
+        target = worksheet[patch.cell]
+        style_source = worksheet[patch.source_cell]
+        assert target._style == style_source._style
+        assert target.style_id == style_source.style_id
+        assert target.style_id == duplicate_style_id
+        assert target.style_id != patch.after
+    finally:
+        workbook.close()
+
+
+@pytest.mark.parametrize("source_cell", [None, "Z99"])
+def test_copy_style_semantic_validation_requires_materialized_source_cell(
+    tmp_path: Path,
+    source_cell: str | None,
+) -> None:
+    source = tmp_path / f"missing-style-source-{source_cell or 'none'}.xlsx"
+    generate_demo_workbook(source)
+    patch = next(item for item in _plan(source).patches if item.kind == PatchKind.COPY_STYLE)
+    patch.source_cell = source_cell
+
+    with pytest.raises(PatchValidationError, match=r"no source cell|source is missing"):
+        ooxml_patch._validate_semantics(source, [patch])

--- a/tests/unit/test_diff_and_reports.py
+++ b/tests/unit/test_diff_and_reports.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from openpyxl import Workbook
-from openpyxl.styles import PatternFill
+from openpyxl.styles import Border, PatternFill, Side
 from openpyxl.workbook.defined_name import DefinedName
 from openpyxl.worksheet.datavalidation import DataValidation
 
@@ -14,6 +14,7 @@ from workbooklens.models import CellSnapshot, SheetSnapshot, WorkbookSnapshot
 from workbooklens.reports import write_scan_report
 from workbooklens.reports.scan import build_sarif
 from workbooklens.scanner import scan_workbook
+from workbooklens.snapshot import create_snapshot
 
 
 def _diff_workbooks(directory: Path) -> tuple[Path, Path]:
@@ -168,6 +169,73 @@ def test_ambiguous_sheet_rename_degrades_to_add_and_remove() -> None:
     assert not any(change.change_type == "sheet_renamed" for change in changes)
     assert [change.change_type for change in changes].count("sheet_removed") == 2
     assert [change.change_type for change in changes].count("sheet_added") == 1
+
+
+def test_snapshot_records_declared_content_and_saved_layout(tmp_path: Path) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    assert sheet is not None
+    sheet["A1"] = "Title"
+    sheet["G24"] = "Visible content"
+    sheet["IV27"].border = Border(left=Side(style="thin"))
+    sheet.row_dimensions[31].height = 66
+    sheet.column_dimensions["G"].width = 21.75
+    sheet.sheet_view.topLeftCell = "A3"
+    sheet.sheet_view.zoomScale = 115
+    path = tmp_path / "layout.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    snapshot = create_snapshot(path).sheets[0]
+
+    assert snapshot.declared_dimension == "A1:IV27"
+    assert snapshot.content_dimension == "A1:G24"
+    assert snapshot.row_heights["31"] == 66
+    assert snapshot.column_widths["G"] == 21.75
+    assert snapshot.view_top_left_cell == "A3"
+    assert snapshot.view_zoom_scale == 115
+
+
+def test_diff_summarizes_large_formatting_tail_and_layout_changes() -> None:
+    styled_blanks = {
+        f"{column}{row}": CellSnapshot(
+            coordinate=f"{column}{row}",
+            data_type="n",
+            style_id=1,
+            style_fingerprint="tail-style",
+        )
+        for row in (26, 27)
+        for column in ("AI", "AJ", "AK", "AL", "AM", "AN", "AO", "AP")
+    }
+    before_sheet = _sheet("Data", 0)
+    before_sheet.declared_dimension = "A1:AP31"
+    before_sheet.content_dimension = "A1:G28"
+    before_sheet.cells.update(styled_blanks)
+    before_sheet.row_heights = {"5": 30.0, "29": 18.0, "30": 18.0, "31": 66.0}
+    before_sheet.column_widths = {"G": 18.25}
+    before_sheet.view_top_left_cell = "A3"
+    before_sheet.view_zoom_scale = 115
+    after_sheet = _sheet("Data", 0)
+    after_sheet.declared_dimension = "A1:G28"
+    after_sheet.content_dimension = "A1:G28"
+    after_sheet.row_heights = {"5": 70.0}
+    after_sheet.column_widths = {"G": 21.75}
+    after_sheet.view_top_left_cell = "A1"
+    after_sheet.view_zoom_scale = 85
+
+    diff = compare_snapshots(
+        _snapshot_with_sheets(before_sheet, source="before"),
+        _snapshot_with_sheets(after_sheet, source="after"),
+    )
+
+    assert not [change for change in diff.cell_changes if change.cell in styled_blanks]
+    structural_types = [change.change_type for change in diff.structural_changes]
+    assert structural_types.count("formatting_tail_cells_removed") == 1
+    assert "declared_dimension" in structural_types
+    assert "row_height" in structural_types
+    assert "column_width" in structural_types
+    assert "view_top_left_cell" in structural_types
+    assert "view_zoom_scale" in structural_types
 
 
 def test_diff_report_is_self_contained_and_has_json_twin(tmp_path: Path) -> None:

--- a/tests/unit/test_layout_edge_regressions.py
+++ b/tests/unit/test_layout_edge_regressions.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+from openpyxl.styles import Alignment, Border, PatternFill, Side
+
+from workbooklens.layout import measure_text_cell
+from workbooklens.models import PatchKind
+from workbooklens.repair.engine import apply_patch_plan
+from workbooklens.repair.planning import build_patch_plan
+from workbooklens.scanner import ScanResult, scan_workbook
+
+
+def _scan(workbook: Workbook, path: Path) -> ScanResult:
+    workbook.save(path)
+    workbook.close()
+    return scan_workbook(path)
+
+
+def _findings(scan: ScanResult, rule_id: str):
+    return [finding for finding in scan.findings if finding.rule_id == rule_id]
+
+
+def test_text_at_right_sheet_boundary_is_not_treated_as_natural_overflow(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["XFD1"] = "Text cannot overflow beyond the final worksheet column"
+    worksheet.column_dimensions["XFD"].width = 5
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "right-sheet-boundary.xlsx")
+
+    assert [finding.location for finding in _findings(scan, "WL016_TEXT_DISPLAY_RISK")] == ["XFD1"]
+
+
+def test_right_aligned_text_at_left_sheet_boundary_is_reported(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Right-aligned text cannot overflow beyond column A"
+    worksheet["A1"].alignment = Alignment(horizontal="right")
+    worksheet.column_dimensions["A"].width = 5
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "left-sheet-boundary.xlsx")
+
+    assert [finding.location for finding in _findings(scan, "WL016_TEXT_DISPLAY_RISK")] == ["A1"]
+
+
+def test_word_aware_wrapping_does_not_underestimate_row_height(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Alpha Bravo Charlie"
+    worksheet["A1"].alignment = Alignment(wrap_text=True)
+    worksheet.column_dimensions["A"].width = 10
+    worksheet.row_dimensions[1].height = 32
+
+    scan = _scan(workbook, tmp_path / "word-wrap-height.xlsx")
+
+    finding = _findings(scan, "WL016_TEXT_DISPLAY_RISK")[0]
+    assert finding.location == "A1"
+    assert finding.evidence.expected["required_lines"] == 3
+    row_patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_ROW_HEIGHT)
+    assert row_patch.after["height"] > 32
+
+
+def test_single_row_merged_wrap_gets_height_even_without_an_explicit_row_height(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.merge_cells("A1:C1")
+    worksheet["A1"] = "A merged wrapped title that requires multiple visible lines"
+    worksheet["A1"].alignment = Alignment(wrap_text=True)
+    for column in ("A", "B", "C"):
+        worksheet.column_dimensions[column].width = 5
+
+    scan = _scan(workbook, tmp_path / "merged-auto-height.xlsx")
+
+    finding = _findings(scan, "WL016_TEXT_DISPLAY_RISK")[0]
+    assert finding.location == "A1"
+    assert any(patch.kind == PatchKind.SET_ROW_HEIGHT for patch in scan.patches)
+
+
+def test_repeated_overflow_width_patch_contains_the_measured_text(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    for row in range(1, 4):
+        worksheet.cell(row, 7, "Repeated long text at the right edge")
+        worksheet.cell(row, 7).border = Border(right=thin)
+    worksheet.column_dimensions["G"].width = 8
+
+    scan = _scan(workbook, tmp_path / "sufficient-shared-width.xlsx")
+
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_COLUMN_WIDTH)
+    measurements = [measure_text_cell(worksheet, worksheet.cell(row, 7)) for row in range(1, 4)]
+    assert all(measurement is not None for measurement in measurements)
+    assert patch.after["width"] >= max(
+        measurement.required_width for measurement in measurements if measurement is not None
+    )
+
+
+def _formatting_tail_workbook() -> Workbook:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    fill = PatternFill(fill_type="solid", fgColor="FFFF00")
+    for row in range(50, 54):
+        for column in range(16, 20):
+            worksheet.cell(row, column).fill = fill
+    return workbook
+
+
+def test_formatting_tail_does_not_offer_cleanup_for_custom_height_cells(
+    tmp_path: Path,
+) -> None:
+    workbook = _formatting_tail_workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.row_dimensions[52].height = 24
+
+    scan = _scan(workbook, tmp_path / "custom-height-formatting-tail.xlsx")
+
+    assert not any(patch.kind == PatchKind.CLEAR_FORMATTING_TAIL for patch in scan.patches)
+
+
+def test_formatting_tail_does_not_offer_an_unapplicable_hidden_row_cleanup(
+    tmp_path: Path,
+) -> None:
+    workbook = _formatting_tail_workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.row_dimensions[52].hidden = True
+
+    scan = _scan(workbook, tmp_path / "hidden-row-formatting-tail.xlsx")
+
+    assert not any(patch.kind == PatchKind.CLEAR_FORMATTING_TAIL for patch in scan.patches)
+
+
+def test_hidden_sheet_formatting_tail_is_report_only(tmp_path: Path) -> None:
+    workbook = _formatting_tail_workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.title = "Hidden tail"
+    worksheet.sheet_state = "hidden"
+    workbook.create_sheet("Visible")
+
+    scan = _scan(workbook, tmp_path / "hidden-sheet-formatting-tail.xlsx")
+
+    assert _findings(scan, "WL018_USED_RANGE_INFLATION")
+    assert not any(patch.kind == PatchKind.CLEAR_FORMATTING_TAIL for patch in scan.patches)
+
+
+def test_absent_internal_border_hole_is_materialized_and_repaired(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin", color="FF336699")
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in range(1, 6):
+        for column in range(1, 6):
+            if (row, column) == (3, 3):
+                continue
+            worksheet.cell(row, column, f"R{row}C{column}").border = full
+    worksheet["B3"].border = Border(left=thin, top=thin, bottom=thin)
+    worksheet["D3"].border = Border(right=thin, top=thin, bottom=thin)
+    worksheet["C2"].border = Border(left=thin, right=thin, top=thin)
+    worksheet["C4"].border = Border(left=thin, right=thin, bottom=thin)
+    source = tmp_path / "absent-border-hole.xlsx"
+
+    scan = _scan(workbook, source)
+
+    findings = _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+    json.dumps(
+        {
+            "findings": [finding.model_dump(mode="json") for finding in scan.findings],
+            "patches": [patch.model_dump(mode="json") for patch in scan.patches],
+        },
+        sort_keys=True,
+    )
+    assert any(finding.location == "C3" for finding in findings)
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.kind == PatchKind.COPY_BORDER and patch.cell == "C3"
+    ]
+    assert {patch.after["target_edge"] for patch in patches} == {
+        "left",
+        "right",
+        "top",
+        "bottom",
+    }
+
+    output = tmp_path / "absent-border-hole-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id for patch in patches},
+        accept_layout_risk=True,
+    )
+
+    repaired = load_workbook(output)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    assert repaired_sheet["C3"].value is None
+    assert all(
+        getattr(repaired_sheet["C3"].border, edge).style == "thin"
+        for edge in ("left", "right", "top", "bottom")
+    )
+    repaired.close()
+    assert not _findings(scan_workbook(output), "WL017_BORDER_EDGE_INCONSISTENCY")
+
+
+def test_measurement_compact_twenty_one_column_sheet_gets_zoom_repair(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in range(1, 9):
+        worksheet.row_dimensions[row].height = 15
+        for column in range(1, 22):
+            cell = worksheet.cell(row, column, f"R{row}C{column}")
+            cell.border = full
+            if row == 1:
+                worksheet.column_dimensions[cell.column_letter].width = 5
+    worksheet.sheet_view.zoomScale = 200
+    source = tmp_path / "measurement-compact-wide-sheet.xlsx"
+
+    scan = _scan(workbook, source)
+
+    assert _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert patch.after["zoom_scale"] < 200
+    output = tmp_path / "measurement-compact-wide-sheet-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+    )
+    assert not _findings(scan_workbook(output), "WL020_SAVED_VIEW_OFF_CONTENT")

--- a/tests/unit/test_layout_measurements.py
+++ b/tests/unit/test_layout_measurements.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Protection, Side
+
+from workbooklens.layout import (
+    WhitespaceTail,
+    find_formatting_tail,
+    find_whitespace_tail,
+    measure_text_cell,
+    visual_border_signature,
+    whitespace_tail_layout_fingerprint,
+)
+
+
+def test_visual_border_signature_does_not_materialize_neighbors() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["C3"] = "value"
+    before = set(worksheet._cells)
+
+    visual_border_signature(worksheet, worksheet["C3"])
+
+    assert set(worksheet._cells) == before
+    workbook.close()
+
+
+def test_measure_text_excludes_layouts_that_need_excel_rendering() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "long text"
+    worksheet["A1"].alignment = Alignment(shrink_to_fit=True)
+    worksheet["B1"] = "long text"
+    worksheet["B1"].alignment = Alignment(text_rotation=45)
+    worksheet["C1"] = "long text"
+    worksheet["C1"].alignment = Alignment(indent=1)
+    worksheet["D1"] = "long merged text"
+    worksheet.merge_cells("D1:E2")
+
+    assert measure_text_cell(worksheet, worksheet["A1"]) is None
+    assert measure_text_cell(worksheet, worksheet["B1"]) is None
+    assert measure_text_cell(worksheet, worksheet["C1"]) is None
+    assert measure_text_cell(worksheet, worksheet["D1"]) is None
+    workbook.close()
+
+
+def test_formatting_tail_preserves_exact_sparse_coordinates() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    fill = PatternFill(fill_type="solid", fgColor="FFFF00")
+    coordinates = {
+        (30, 20),
+        (30, 21),
+        (30, 22),
+        (30, 23),
+        (30, 24),
+        (31, 20),
+        (31, 21),
+        (31, 22),
+        (31, 24),
+        (31, 25),
+        (32, 20),
+        (32, 21),
+        (32, 22),
+        (32, 23),
+        (32, 24),
+        (32, 25),
+        (33, 20),
+        (33, 21),
+        (33, 22),
+        (33, 23),
+    }
+    for row, column in coordinates:
+        worksheet.cell(row, column).fill = fill
+
+    tail = find_formatting_tail(worksheet)
+
+    assert tail is not None
+    assert len(tail.cell_coordinates) == len(coordinates)
+    assert "W31" not in tail.cell_coordinates
+    assert "T31:V31" in tail.cell_ranges
+    assert "X31:Y31" in tail.cell_ranges
+    workbook.close()
+
+
+def test_broad_column_dimension_style_is_not_a_formatting_tail() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    dimension = worksheet.column_dimensions["L"]
+    dimension.min = 12
+    dimension.max = 16_384
+    dimension.width = 12.0
+
+    assert find_formatting_tail(worksheet) is None
+    workbook.close()
+
+
+def test_formatting_tail_excludes_custom_height_blank_rows() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    fill = PatternFill(fill_type="solid", fgColor="FFFF00")
+    for row in range(50, 54):
+        for column in range(16, 20):
+            worksheet.cell(row, column).fill = fill
+    worksheet.row_dimensions[54].height = 24.0
+    worksheet.row_dimensions[55].fill = fill
+
+    tail = find_formatting_tail(worksheet)
+
+    assert tail is not None
+    assert 54 not in tail.empty_rows
+    assert 55 in tail.empty_rows
+    assert tail.observed_max_row == 55
+    workbook.close()
+
+
+def test_single_sided_shared_border_is_visually_continuous() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "left"
+    worksheet["B1"] = "right"
+    worksheet["B1"].border = Border(left=Side(style="thin"))
+
+    signature = visual_border_signature(worksheet, worksheet["A1"])
+
+    assert signature[1][0] == "thin"
+    workbook.close()
+
+
+def test_whitespace_tail_marks_nondefault_cell_styles_for_preservation() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    worksheet["A9"] = " "
+    worksheet["A10"] = " "
+    worksheet["A10"].font = Font(bold=True)
+    worksheet["A11"] = " "
+    worksheet["A11"].alignment = Alignment(horizontal="center")
+    worksheet["A11"].protection = Protection(locked=False, hidden=True)
+
+    tail = find_whitespace_tail(worksheet)
+
+    assert tail is not None
+    assert tail.cell_coordinates == ("A9", "A10", "A11")
+    assert dict(tail.preserve_style_ids) == {
+        "A10": worksheet["A10"].style_id,
+        "A11": worksheet["A11"].style_id,
+    }
+    assert tail.result_dimension == "A1:A11"
+    workbook.close()
+
+
+def test_whitespace_tail_fingerprint_uses_coordinate_order_not_json_key_order() -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    for coordinate in ("A9", "A10", "A11"):
+        worksheet[coordinate] = " "
+        worksheet[coordinate].font = Font(bold=True)
+    tail = find_whitespace_tail(worksheet)
+    assert tail is not None
+    reordered = WhitespaceTail(
+        cell_coordinates=tail.cell_coordinates,
+        cell_ranges=tail.cell_ranges,
+        row_ranges=tail.row_ranges,
+        content_min_row=tail.content_min_row,
+        content_min_column=tail.content_min_column,
+        content_max_row=tail.content_max_row,
+        content_max_column=tail.content_max_column,
+        observed_dimension=tail.observed_dimension,
+        result_dimension=tail.result_dimension,
+        preserve_style_ids=tuple(sorted(tail.preserve_style_ids, key=lambda item: item[0])),
+    )
+
+    assert whitespace_tail_layout_fingerprint(
+        worksheet, tail
+    ) == whitespace_tail_layout_fingerprint(worksheet, reordered)
+    workbook.close()

--- a/tests/unit/test_layout_rules.py
+++ b/tests/unit/test_layout_rules.py
@@ -1,0 +1,1170 @@
+from __future__ import annotations
+
+from copy import copy
+from pathlib import Path
+
+import pytest
+from openpyxl import Workbook, load_workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.worksheet.views import Pane
+from openpyxl.worksheet.worksheet import Worksheet
+
+from workbooklens.layout import measure_text_cell
+from workbooklens.models import PatchKind, PatchRisk
+from workbooklens.repair.engine import apply_patch_plan
+from workbooklens.repair.planning import build_patch_plan
+from workbooklens.rules.builtin import _finite_nonnegative_pane_split
+from workbooklens.scanner import ScanResult, scan_workbook
+
+
+def _scan(workbook: Workbook, path: Path) -> ScanResult:
+    workbook.save(path)
+    workbook.close()
+    return scan_workbook(path)
+
+
+def _findings(scan: ScanResult, rule_id: str):
+    return [finding for finding in scan.findings if finding.rule_id == rule_id]
+
+
+def test_wrapped_text_with_small_explicit_height_gets_review_patch(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "A deliberately long wrapped heading that needs several lines"
+    worksheet["A1"].alignment = Alignment(wrap_text=True)
+    worksheet.column_dimensions["A"].width = 6
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "wrapped.xlsx")
+
+    findings = _findings(scan, "WL016_TEXT_DISPLAY_RISK")
+    assert [finding.location for finding in findings] == ["A1"]
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_ROW_HEIGHT)
+    assert patch.after["height"] > 15
+    assert not patch.safe
+    assert patch.risk == PatchRisk.LAYOUT_REVIEW
+
+
+def test_auto_height_and_natural_overflow_are_not_reported(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "A long wrapped title that Excel may auto-size"
+    worksheet["A1"].alignment = Alignment(wrap_text=True)
+    worksheet.column_dimensions["A"].width = 5
+    worksheet["C3"] = "A long unwrapped title with blank cells to its right"
+    worksheet.column_dimensions["C"].width = 5
+
+    scan = _scan(workbook, tmp_path / "natural-overflow.xlsx")
+
+    assert not _findings(scan, "WL016_TEXT_DISPLAY_RISK")
+
+
+def test_blocked_overflow_uses_atomic_wrap_and_row_height(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Long text that cannot spill into the occupied adjacent cell"
+    worksheet["B1"] = "blocker"
+    worksheet.column_dimensions["A"].width = 6
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "blocked.xlsx")
+
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+    ]
+    assert {patch.kind for patch in patches} == {
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_ROW_HEIGHT,
+    }
+    assert len({patch.atomic_group for patch in patches}) == 1
+    assert patches[0].atomic_group is not None
+    assert all(not patch.safe and patch.risk == PatchRisk.LAYOUT_REVIEW for patch in patches)
+
+
+def test_default_height_blocked_overflow_applies_without_stale_layout_fingerprint(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Long text in an automatic-height row that must wrap inside its border"
+    worksheet["B1"] = "blocker"
+    worksheet.column_dimensions["A"].width = 7
+    source = tmp_path / "default-height-blocked.xlsx"
+    scan = _scan(workbook, source)
+
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.cell == "A1" and patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+    ]
+    assert {patch.kind for patch in patches} == {
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_ROW_HEIGHT,
+    }
+
+    output = tmp_path / "default-height-blocked-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id for patch in patches},
+        accept_layout_risk=True,
+    )
+
+    repaired = load_workbook(output)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    assert repaired_sheet["A1"].alignment.wrap_text
+    assert repaired_sheet.row_dimensions[1].height is not None
+    repaired.close()
+    assert not _findings(scan_workbook(output), "WL016_TEXT_DISPLAY_RISK")
+
+
+def test_row_height_covers_existing_vertical_and_new_horizontal_issue(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Existing wrapped vertical clipping"
+    worksheet["A1"].alignment = Alignment(wrap_text=True)
+    worksheet["B1"] = "New horizontal overflow needs substantially more wrapped height"
+    worksheet["C1"] = "blocker"
+    worksheet["D1"] = "peer"
+    worksheet["E1"] = "peer"
+    for coordinate in ("C1", "D1", "E1"):
+        worksheet[coordinate].alignment = Alignment(wrap_text=True)
+    worksheet.column_dimensions["A"].width = 10
+    worksheet.column_dimensions["B"].width = 6
+    worksheet.row_dimensions[1].height = 15
+
+    source = tmp_path / "mixed-row-display-risk.xlsx"
+    scan = _scan(workbook, source)
+
+    findings = _findings(scan, "WL016_TEXT_DISPLAY_RISK")
+    assert {finding.location for finding in findings} == {"A1", "B1"}
+    row_patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_ROW_HEIGHT)
+    wrap_patch = next(
+        patch
+        for patch in scan.patches
+        if patch.kind == PatchKind.SET_WRAP_TEXT and patch.cell == "B1"
+    )
+    measured = load_workbook(source)
+    measured_sheet = measured.active
+    assert measured_sheet is not None
+    wrapped_measurement = measure_text_cell(measured_sheet, measured_sheet["B1"], assume_wrap=True)
+    assert wrapped_measurement is not None
+    assert row_patch.after["height"] >= wrapped_measurement.required_height
+    measured.close()
+    assert row_patch.atomic_group == wrap_patch.atomic_group
+
+    repaired = load_workbook(source)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    alignment = copy(repaired_sheet["B1"].alignment)
+    alignment.wrap_text = True
+    repaired_sheet["B1"].alignment = alignment
+    repaired_sheet.row_dimensions[1].height = row_patch.after["height"]
+    repaired_path = tmp_path / "mixed-row-display-risk-repaired.xlsx"
+    repaired.save(repaired_path)
+    repaired.close()
+
+    assert not _findings(scan_workbook(repaired_path), "WL016_TEXT_DISPLAY_RISK")
+
+
+def test_hidden_adjacent_columns_do_not_count_as_natural_overflow_space(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Hidden overflow"
+    worksheet["D1"] = "visible blocker"
+    worksheet.column_dimensions["A"].width = 5
+    for column in ("B", "C"):
+        worksheet.column_dimensions[column].width = 10
+        worksheet.column_dimensions[column].hidden = True
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "hidden-overflow-space.xlsx")
+
+    assert [finding.location for finding in _findings(scan, "WL016_TEXT_DISPLAY_RISK")] == ["A1"]
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.cell == "A1" and patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+    ]
+    assert {patch.kind for patch in patches} == {
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_ROW_HEIGHT,
+    }
+
+
+def test_repeated_boundary_overflow_uses_one_conservative_column_width(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    for row in range(1, 5):
+        worksheet.cell(row, 7, "Repeated long text at the right edge")
+        worksheet.cell(row, 7).border = Border(right=thin)
+    worksheet.column_dimensions["G"].width = 8
+
+    source = tmp_path / "repeated-overflow.xlsx"
+    scan = _scan(workbook, source)
+
+    width_patches = [patch for patch in scan.patches if patch.kind == PatchKind.SET_COLUMN_WIDTH]
+    assert len(width_patches) == 1
+    assert width_patches[0].after["column"] == "G"
+    assert 8.5 <= width_patches[0].after["width"] <= 40
+    assert not any(patch.kind == PatchKind.SET_WRAP_TEXT for patch in scan.patches)
+    assert all(
+        finding.patch_ids == [width_patches[0].id]
+        for finding in _findings(scan, "WL016_TEXT_DISPLAY_RISK")
+    )
+
+    repaired = load_workbook(source)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    repaired_sheet.column_dimensions["G"].width = width_patches[0].after["width"]
+    repaired_path = tmp_path / "repeated-overflow-repaired.xlsx"
+    repaired.save(repaired_path)
+    repaired.close()
+    repaired_scan = scan_workbook(repaired_path)
+    assert not _findings(repaired_scan, "WL016_TEXT_DISPLAY_RISK")
+
+
+def test_repeated_overflow_at_width_cap_falls_back_to_atomic_wrap_and_height(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    for row in range(1, 4):
+        worksheet.cell(row, 1, "x" * 120)
+        worksheet.cell(row, 1).border = Border(right=thin)
+        worksheet.row_dimensions[row].height = 15
+    worksheet.column_dimensions["A"].width = 40
+
+    scan = _scan(workbook, tmp_path / "width-cap.xlsx")
+
+    assert not any(patch.kind == PatchKind.SET_COLUMN_WIDTH for patch in scan.patches)
+    for row in range(1, 4):
+        row_patches = [
+            patch
+            for patch in scan.patches
+            if patch.cell == f"A{row}"
+            and patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+        ]
+        assert {patch.kind for patch in row_patches} == {
+            PatchKind.SET_WRAP_TEXT,
+            PatchKind.SET_ROW_HEIGHT,
+        }
+        assert len({patch.atomic_group for patch in row_patches}) == 1
+        assert row_patches[0].atomic_group is not None
+
+
+def test_extreme_blocked_overflow_is_finding_only_above_excel_row_height_limit(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "x" * 2_000
+    worksheet["B1"] = "blocker"
+    worksheet.column_dimensions["A"].width = 6
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "extreme-overflow.xlsx")
+
+    findings = _findings(scan, "WL016_TEXT_DISPLAY_RISK")
+    assert [finding.location for finding in findings] == ["A1"]
+    assert findings[0].patch_ids == []
+    assert not any(
+        patch.cell == "A1" and patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+        for patch in scan.patches
+    )
+
+
+def test_overflow_crossing_a_later_blank_cell_border_is_reported(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "Long text that crosses more than one otherwise blank cell"
+    worksheet.column_dimensions["A"].width = 5
+    worksheet.column_dimensions["B"].width = 5
+    worksheet["B1"].border = Border(right=Side(style="thin"))
+    worksheet.row_dimensions[1].height = 15
+
+    scan = _scan(workbook, tmp_path / "later-border.xlsx")
+
+    assert [finding.location for finding in _findings(scan, "WL016_TEXT_DISPLAY_RISK")] == ["A1"]
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+    ]
+    assert {patch.kind for patch in patches} == {
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_ROW_HEIGHT,
+    }
+
+
+def test_single_row_merged_title_uses_atomic_wrap_and_height(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.merge_cells("A1:C1")
+    worksheet["A1"] = "A merged title that is substantially wider than the merged region"
+    worksheet.column_dimensions["A"].width = 7
+    worksheet.column_dimensions["B"].width = 7
+    worksheet.column_dimensions["C"].width = 7
+    worksheet.row_dimensions[1].height = 15
+    source = tmp_path / "merged-title.xlsx"
+    scan = _scan(workbook, source)
+
+    findings = _findings(scan, "WL016_TEXT_DISPLAY_RISK")
+    assert [finding.location for finding in findings] == ["A1"]
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.kind in {PatchKind.SET_WRAP_TEXT, PatchKind.SET_ROW_HEIGHT}
+    ]
+    assert {patch.kind for patch in patches} == {
+        PatchKind.SET_WRAP_TEXT,
+        PatchKind.SET_ROW_HEIGHT,
+    }
+    assert len({patch.atomic_group for patch in patches}) == 1
+    assert patches[0].atomic_group is not None
+    assert not any(patch.kind == PatchKind.SET_COLUMN_WIDTH for patch in scan.patches)
+
+    output = tmp_path / "merged-title-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id for patch in patches},
+        accept_layout_risk=True,
+    )
+    repaired = load_workbook(output)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    assert [str(cell_range) for cell_range in repaired_sheet.merged_cells.ranges] == ["A1:C1"]
+    assert repaired_sheet["A1"].alignment.wrap_text
+    assert repaired_sheet.row_dimensions[1].height is not None
+    repaired.close()
+    assert not _findings(scan_workbook(output), "WL016_TEXT_DISPLAY_RISK")
+
+
+def _border_grid(*, remove_both_sides: bool) -> Workbook:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in range(1, 6):
+        for column in range(1, 4):
+            cell = worksheet.cell(row, column, f"R{row}C{column}")
+            cell.border = full
+    worksheet["B3"].border = Border(left=thin, top=thin, bottom=thin)
+    if remove_both_sides:
+        worksheet["C3"].border = Border(right=thin, top=thin, bottom=thin)
+    return workbook
+
+
+def test_single_sided_shared_border_is_not_reported(tmp_path: Path) -> None:
+    scan = _scan(_border_grid(remove_both_sides=False), tmp_path / "one-sided.xlsx")
+
+    assert not _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+
+
+def test_border_missing_on_both_sides_gets_edge_only_patch(tmp_path: Path) -> None:
+    scan = _scan(_border_grid(remove_both_sides=True), tmp_path / "missing-border.xlsx")
+
+    findings = _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+    assert len(findings) == 1
+    patches = [patch for patch in scan.patches if patch.kind == PatchKind.COPY_BORDER]
+    assert len(patches) == 1
+    assert patches[0].after["target_edge"] in {"left", "right"}
+    assert patches[0].source_cell is not None
+
+
+def test_internal_blank_cell_with_both_shared_sides_missing_gets_edge_only_patch(
+    tmp_path: Path,
+) -> None:
+    workbook = _border_grid(remove_both_sides=True)
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["B3"] = None
+
+    scan = _scan(workbook, tmp_path / "blank-cell-missing-border.xlsx")
+
+    findings = _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+    assert [finding.location for finding in findings] == ["B3"]
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.kind == PatchKind.COPY_BORDER and patch.cell == "B3"
+    ]
+    assert len(patches) == 1
+    assert set(patches[0].after) == {"target_edge", "source_edge"}
+    assert patches[0].after["target_edge"] in {"left", "right", "top", "bottom"}
+    assert patches[0].after["source_edge"] in {"left", "right", "top", "bottom"}
+    assert patches[0].source_cell is not None
+
+
+def test_border_rule_does_not_box_intentional_ragged_note_cell(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in range(1, 8):
+        for column in range(1, 6):
+            worksheet.cell(row, column, f"R{row}C{column}").border = full
+    worksheet["C8"] = "Open note"
+    worksheet["C8"].border = Border(top=thin)
+
+    scan = _scan(workbook, tmp_path / "ragged-note.xlsx")
+
+    assert not any(
+        finding.location == "C8" for finding in _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+    )
+    assert not any(
+        patch.kind == PatchKind.COPY_BORDER and patch.cell == "C8" for patch in scan.patches
+    )
+
+
+def _rectangular_border_grid(rows: int = 5, columns: int = 5) -> Workbook:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in range(1, rows + 1):
+        for column in range(1, columns + 1):
+            worksheet.cell(row, column, f"R{row}C{column}").border = full
+    return workbook
+
+
+def test_completely_borderless_internal_hole_is_repaired_and_rescans_clean(
+    tmp_path: Path,
+) -> None:
+    workbook = _rectangular_border_grid()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    worksheet["C3"].border = Border()
+    worksheet["B3"].border = Border(left=thin, top=thin, bottom=thin)
+    worksheet["D3"].border = Border(right=thin, top=thin, bottom=thin)
+    worksheet["C2"].border = Border(left=thin, right=thin, top=thin)
+    worksheet["C4"].border = Border(left=thin, right=thin, bottom=thin)
+    source = tmp_path / "complete-border-hole.xlsx"
+
+    scan = _scan(workbook, source)
+
+    finding = next(
+        finding
+        for finding in _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+        if finding.location == "C3"
+    )
+    patches = [
+        patch
+        for patch in scan.patches
+        if patch.kind == PatchKind.COPY_BORDER and patch.cell == "C3"
+    ]
+    assert len(patches) == 4
+    assert set(finding.patch_ids) == {patch.id for patch in patches}
+    assert {patch.after["target_edge"] for patch in patches} == {
+        "left",
+        "right",
+        "top",
+        "bottom",
+    }
+    assert len({patch.atomic_group for patch in patches}) == 1
+    assert patches[0].atomic_group is not None
+
+    output = tmp_path / "complete-border-hole-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id for patch in patches},
+        accept_layout_risk=True,
+    )
+
+    assert not _findings(scan_workbook(output), "WL017_BORDER_EDGE_INCONSISTENCY")
+
+
+def test_all_four_table_perimeter_edges_are_repaired_and_rescan_clean(
+    tmp_path: Path,
+) -> None:
+    workbook = _rectangular_border_grid()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    worksheet["A3"].border = Border(right=thin, top=thin, bottom=thin)
+    worksheet["E3"].border = Border(left=thin, top=thin, bottom=thin)
+    worksheet["C1"].border = Border(left=thin, right=thin, bottom=thin)
+    worksheet["C5"].border = Border(left=thin, right=thin, top=thin)
+    source = tmp_path / "missing-table-perimeter.xlsx"
+
+    scan = _scan(workbook, source)
+
+    findings = _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+    assert {finding.location for finding in findings} == {"A3", "C1", "C5", "E3"}
+    patches = [patch for patch in scan.patches if patch.kind == PatchKind.COPY_BORDER]
+    assert {(patch.cell, patch.after["target_edge"]) for patch in patches} == {
+        ("A3", "left"),
+        ("E3", "right"),
+        ("C1", "top"),
+        ("C5", "bottom"),
+    }
+
+    output = tmp_path / "missing-table-perimeter-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id for patch in patches},
+        accept_layout_risk=True,
+    )
+
+    assert not _findings(scan_workbook(output), "WL017_BORDER_EDGE_INCONSISTENCY")
+
+
+def test_border_finding_below_point_nine_five_has_no_patch(tmp_path: Path) -> None:
+    workbook = _rectangular_border_grid(rows=6, columns=4)
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    for row in (3, 6):
+        worksheet.cell(row, 2).border = Border(left=thin, top=thin, bottom=thin)
+        worksheet.cell(row, 3).border = Border(right=thin, top=thin, bottom=thin)
+
+    scan = _scan(workbook, tmp_path / "low-confidence-border.xlsx")
+
+    finding = next(
+        finding
+        for finding in _findings(scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+        if finding.location == "B3"
+    )
+    assert 0.75 <= float(finding.confidence) < 0.95
+    assert finding.patch_ids == []
+    assert not any(
+        patch.kind == PatchKind.COPY_BORDER and patch.cell == "B3" for patch in scan.patches
+    )
+
+
+def test_border_rule_skips_merged_target_and_small_or_sparse_rectangles(tmp_path: Path) -> None:
+    merged = _rectangular_border_grid()
+    merged_sheet = merged.active
+    assert merged_sheet is not None
+    merged_sheet.merge_cells("B3:C3")
+    merged_sheet["B3"].border = Border()
+    merged_scan = _scan(merged, tmp_path / "merged-border-gap.xlsx")
+    assert not any(
+        finding.location in {"B3", "C3"}
+        for finding in _findings(merged_scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+    )
+
+    small = _rectangular_border_grid(rows=2, columns=3)
+    small_sheet = small.active
+    assert small_sheet is not None
+    thin = Side(style="thin")
+    small_sheet["B1"].border = Border(left=thin, top=thin, bottom=thin)
+    small_sheet["C1"].border = Border(right=thin, top=thin, bottom=thin)
+    small_scan = _scan(small, tmp_path / "small-border-grid.xlsx")
+    assert not _findings(small_scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+
+    sparse = Workbook()
+    sparse_sheet = sparse.active
+    assert sparse_sheet is not None
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for coordinate in ("A1", "B1", "B2", "C2", "C3", "D3", "C4", "D4"):
+        sparse_sheet[coordinate] = coordinate
+        sparse_sheet[coordinate].border = full
+    sparse_sheet["B2"].border = Border(left=thin, top=thin, bottom=thin)
+    sparse_sheet["C2"].border = Border(right=thin, top=thin, bottom=thin)
+    sparse_scan = _scan(sparse, tmp_path / "sparse-border-grid.xlsx")
+    assert not _findings(sparse_scan, "WL017_BORDER_EDGE_INCONSISTENCY")
+
+
+def test_exact_formatting_tail_patch_and_broad_column_negative(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    fill = PatternFill(fill_type="solid", fgColor="FFFF00")
+    for row in range(30, 34):
+        for column in range(10, 14):
+            worksheet.cell(row, column).fill = fill
+    scan = _scan(workbook, tmp_path / "tail.xlsx")
+
+    patches = [patch for patch in scan.patches if patch.kind == PatchKind.CLEAR_FORMATTING_TAIL]
+    assert len(patches) == 1
+    assert len(patches[0].after["cells"]) == 16
+    assert patches[0].after["result_dimension"] == "A1"
+
+    negative = Workbook()
+    negative_sheet = negative.active
+    assert negative_sheet is not None
+    negative_sheet["A1"] = "content"
+    dimension = negative_sheet.column_dimensions["L"]
+    dimension.min = 12
+    dimension.max = 16_384
+    dimension.width = 12
+    negative_scan = _scan(negative, tmp_path / "broad-column.xlsx")
+    assert not _findings(negative_scan, "WL018_USED_RANGE_INFLATION")
+
+
+def test_identifier_patch_is_width_only_and_preserves_numeric_semantics(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["J1"] = "联系电话"
+    worksheet["J2"] = 19_885_186_321
+    worksheet.column_dimensions["J"].width = 8
+    worksheet["K1"] = "金额"
+    worksheet["K2"] = 19_885_186_321
+    worksheet.column_dimensions["K"].width = 8
+
+    scan = _scan(workbook, tmp_path / "identifier.xlsx")
+
+    findings = _findings(scan, "WL019_IDENTIFIER_SCIENTIFIC_NOTATION")
+    assert [finding.location for finding in findings] == ["J2"]
+    patches = [patch for patch in scan.patches if patch.kind == PatchKind.SET_COLUMN_WIDTH]
+    assert len(patches) == 1
+    assert patches[0].after["column"] == "J"
+    assert patches[0].atomic_group is None
+    assert not any(patch.kind == PatchKind.SET_TEXT for patch in scan.patches)
+    assert findings[0].patch_ids == [patches[0].id]
+
+
+def test_same_column_width_requests_are_coalesced_to_the_sufficient_maximum(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["J1"] = "联系电话"
+    worksheet["J2"] = 19_885_186_321
+    thin = Side(style="thin")
+    for row in range(3, 6):
+        worksheet.cell(row, 10, "Repeated long text at the right edge")
+        worksheet.cell(row, 10).border = Border(right=thin)
+    worksheet.column_dimensions["J"].width = 8
+
+    source = tmp_path / "coalesced-width.xlsx"
+    scan = _scan(workbook, source)
+
+    width_patches = [patch for patch in scan.patches if patch.kind == PatchKind.SET_COLUMN_WIDTH]
+    assert len(width_patches) == 1
+    assert width_patches[0].after["column"] == "J"
+    assert width_patches[0].after["width"] > 20
+    related = [
+        finding
+        for finding in scan.findings
+        if finding.rule_id in {"WL016_TEXT_DISPLAY_RISK", "WL019_IDENTIFIER_SCIENTIFIC_NOTATION"}
+    ]
+    assert related
+    assert all(finding.patch_ids == [width_patches[0].id] for finding in related)
+
+    output = tmp_path / "coalesced-width-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={width_patches[0].id},
+        accept_layout_risk=True,
+    )
+    repaired_scan = scan_workbook(output)
+    assert not _findings(repaired_scan, "WL016_TEXT_DISPLAY_RISK")
+    assert not _findings(repaired_scan, "WL019_IDENTIFIER_SCIENTIFIC_NOTATION")
+
+
+def test_styled_wrapped_phone_at_old_width_still_gets_sufficient_numeric_preserving_fix(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["J1"] = "联系电话"
+    worksheet["J2"] = 19_885_186_321
+    worksheet["J2"].font = Font(name="仿宋", size=14)
+    worksheet["J2"].alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+    worksheet.column_dimensions["J"].width = 13.6
+
+    source = tmp_path / "styled-phone-width.xlsx"
+    scan = _scan(workbook, source)
+
+    findings = _findings(scan, "WL019_IDENTIFIER_SCIENTIFIC_NOTATION")
+    assert [finding.location for finding in findings] == ["J2"]
+    width_patch = next(
+        patch
+        for patch in scan.patches
+        if patch.kind == PatchKind.SET_COLUMN_WIDTH and patch.cell == "J2"
+    )
+    assert width_patch.after["width"] >= 15.0
+    assert not any(patch.kind == PatchKind.SET_TEXT for patch in scan.patches)
+
+    repaired = load_workbook(source)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    repaired_sheet.column_dimensions["J"].width = width_patch.after["width"]
+    repaired_path = tmp_path / "styled-phone-width-repaired.xlsx"
+    repaired.save(repaired_path)
+    repaired.close()
+
+    repaired_scan = scan_workbook(repaired_path)
+    assert not _findings(repaired_scan, "WL019_IDENTIFIER_SCIENTIFIC_NOTATION")
+    verified = load_workbook(repaired_path, data_only=False)
+    verified_sheet = verified.active
+    assert verified_sheet is not None
+    assert verified_sheet["J2"].value == 19_885_186_321
+    assert verified_sheet["J2"].data_type == "n"
+    verified.close()
+
+
+def test_long_general_identifiers_remain_findings_at_max_width_without_auto_patch(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    values = {
+        "A2": 123_456_789_012,
+        "B2": 123_456_789_012_345,
+        "C2": 1_234_567_890_123_456,
+    }
+    for column, coordinate in zip(("A", "B", "C"), values, strict=True):
+        worksheet[f"{column}1"] = "联系电话"
+        worksheet[coordinate] = values[coordinate]
+        worksheet.column_dimensions[column].width = 40
+
+    scan = _scan(workbook, tmp_path / "long-general-identifiers.xlsx")
+
+    findings = _findings(scan, "WL019_IDENTIFIER_SCIENTIFIC_NOTATION")
+    by_location = {finding.location: finding for finding in findings}
+    assert set(by_location) == set(values)
+    assert all(finding.patch_ids == [] for finding in findings)
+    assert by_location["A2"].evidence.details["precision_recoverable"] is True
+    assert by_location["B2"].evidence.details["precision_recoverable"] is True
+    assert by_location["C2"].evidence.details["precision_recoverable"] is False
+    assert all(finding.evidence.details["width_only_fixable"] is False for finding in findings)
+    assert not any(
+        patch.kind in {PatchKind.SET_COLUMN_WIDTH, PatchKind.SET_TEXT} for patch in scan.patches
+    )
+
+
+def test_saved_view_resets_compact_sheet_and_ignores_sheet_origin_with_panes(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    worksheet.sheet_view.topLeftCell = "A3"
+    worksheet.sheet_view.zoomScale = 115
+    scan = _scan(workbook, tmp_path / "view.xlsx")
+
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert patch.after == {"top_left_cell": "A1"}
+
+    frozen = Workbook()
+    frozen_sheet = frozen.active
+    assert frozen_sheet is not None
+    frozen_sheet["A1"] = "content"
+    frozen_sheet.sheet_view.topLeftCell = "A3"
+    frozen_sheet.freeze_panes = "A2"
+    frozen_scan = _scan(frozen, tmp_path / "frozen-view.xlsx")
+    assert not _findings(frozen_scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    assert not any(patch.kind == PatchKind.SET_SHEET_VIEW for patch in frozen_scan.patches)
+
+
+@pytest.mark.parametrize("value", [-1, float("nan"), float("inf"), float("-inf"), True])
+def test_pane_split_parser_rejects_nonfinite_or_negative_values(value: object) -> None:
+    assert _finite_nonnegative_pane_split(value) is None
+
+
+@pytest.mark.parametrize(
+    ("x_split", "y_split"),
+    [(-1, 1), (16384, 1), (1, 1048576), (1.5, 1)],
+)
+def test_saved_view_fails_safe_for_invalid_frozen_split_counts(
+    tmp_path: Path,
+    x_split: float,
+    y_split: float,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    worksheet.sheet_view.pane = Pane(
+        xSplit=x_split,
+        ySplit=y_split,
+        topLeftCell="A2",
+        activePane="bottomRight",
+        state="frozen",
+    )
+
+    scan = _scan(workbook, tmp_path / f"invalid-frozen-{x_split}-{y_split}.xlsx")
+
+    assert not _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    assert not any(patch.kind == PatchKind.SET_SHEET_VIEW for patch in scan.patches)
+
+
+@pytest.mark.parametrize("top_left", ["XFE1", "A1048577"])
+def test_saved_view_fails_safe_for_out_of_bounds_top_left_cell(
+    tmp_path: Path,
+    top_left: str,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    worksheet.sheet_view.topLeftCell = top_left
+
+    scan = _scan(workbook, tmp_path / f"invalid-top-left-{top_left}.xlsx")
+
+    assert not _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    assert not any(patch.kind == PatchKind.SET_SHEET_VIEW for patch in scan.patches)
+
+
+@pytest.mark.parametrize("top_left", ["XFE1", "A1048577"])
+def test_saved_view_fails_safe_for_out_of_bounds_pane_top_left_cell(
+    tmp_path: Path,
+    top_left: str,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = "content"
+    worksheet.sheet_view.pane = Pane(
+        xSplit=0,
+        ySplit=1,
+        topLeftCell=top_left,
+        activePane="bottomLeft",
+        state="frozen",
+    )
+
+    scan = _scan(workbook, tmp_path / f"invalid-pane-top-left-{top_left}.xlsx")
+
+    assert not _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    assert not any(patch.kind == PatchKind.SET_SHEET_VIEW for patch in scan.patches)
+
+
+def _populate_vertically_scrollable_sheet(worksheet: Worksheet) -> None:
+    for column in range(1, 11):
+        worksheet.column_dimensions[worksheet.cell(1, column).column_letter].width = 12.5
+    for row in range(1, 11):
+        worksheet.row_dimensions[row].height = 100
+        for column in range(1, 11):
+            worksheet.cell(row, column, f"R{row}C{column}")
+
+
+def test_saved_view_allows_default_zoom_for_vertically_scrollable_sheet(
+    tmp_path: Path,
+) -> None:
+    for name, zoom_scale in (("implicit", None), ("explicit", 100)):
+        workbook = Workbook()
+        worksheet = workbook.active
+        assert worksheet is not None
+        _populate_vertically_scrollable_sheet(worksheet)
+        worksheet.sheet_view.zoomScale = zoom_scale
+
+        scan = _scan(workbook, tmp_path / f"{name}-default-scroll-view.xlsx")
+
+        assert not _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+        assert not any(patch.kind == PatchKind.SET_SHEET_VIEW for patch in scan.patches)
+
+
+def test_saved_view_repairs_offset_on_vertically_scrollable_sheet(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    _populate_vertically_scrollable_sheet(worksheet)
+    worksheet.sheet_view.topLeftCell = "A4"
+
+    scan = _scan(workbook, tmp_path / "offset-scroll-view.xlsx")
+
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert finding.evidence.details["vertical_scrolling_expected"] is True
+    assert patch.after == {"top_left_cell": "A1"}
+    output = tmp_path / "offset-scroll-view-fixed.xlsx"
+    apply_patch_plan(
+        tmp_path / "offset-scroll-view.xlsx",
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+    )
+    assert not _findings(scan_workbook(output), "WL020_SAVED_VIEW_OFF_CONTENT")
+
+
+def test_saved_view_reduces_high_zoom_on_vertically_scrollable_sheet(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    _populate_vertically_scrollable_sheet(worksheet)
+    worksheet.sheet_view.zoomScale = 200
+
+    scan = _scan(workbook, tmp_path / "high-zoom-scroll-view.xlsx")
+
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert finding.evidence.details["vertical_scrolling_expected"] is True
+    assert finding.evidence.observed["estimated_height_fit_zoom"] < 50
+    assert patch.after == {"top_left_cell": "A1", "zoom_scale": 80}
+    output = tmp_path / "high-zoom-scroll-view-fixed.xlsx"
+    apply_patch_plan(
+        tmp_path / "high-zoom-scroll-view.xlsx",
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+    )
+    assert not _findings(scan_workbook(output), "WL020_SAVED_VIEW_OFF_CONTENT")
+
+
+def test_saved_view_reduces_zoom_for_wide_compact_content(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for column in range(1, 16):
+        worksheet.cell(1, column, f"Header {column}")
+        worksheet.column_dimensions[worksheet.cell(1, column).column_letter].width = 14
+    worksheet.sheet_view.topLeftCell = "A1"
+    worksheet.sheet_view.zoomScale = 150
+
+    scan = _scan(workbook, tmp_path / "wide-view.xlsx")
+
+    findings = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    assert len(findings) == 1
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert patch.after["top_left_cell"] == "A1"
+    assert 50 <= patch.after["zoom_scale"] < 100
+    assert patch.after["zoom_scale"] == max(
+        50, findings[0].evidence.observed["estimated_fit_zoom"] - 5
+    )
+
+
+def test_saved_view_uses_full_merged_width_and_preserves_fitting_zoom(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.merge_cells("A1:O1")
+    worksheet["A1"] = "Merged heading"
+    for column in range(1, 16):
+        worksheet.column_dimensions[worksheet.cell(2, column).column_letter].width = 7
+    worksheet.sheet_view.topLeftCell = "A3"
+    worksheet.sheet_view.zoomScale = 100
+
+    scan = _scan(workbook, tmp_path / "merged-view.xlsx")
+
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    assert finding.evidence.details["content_bounds"] == "A1:O1"
+    assert finding.evidence.observed["estimated_content_width"] == 105.0
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert patch.after == {"top_left_cell": "A1"}
+
+
+def test_saved_view_fits_compact_content_height_as_well_as_width(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(1, 29):
+        worksheet.cell(row, 1, f"Row {row}")
+        worksheet.row_dimensions[row].height = 18
+    worksheet.row_dimensions[1].height = 26
+    worksheet.row_dimensions[2].height = 52
+    worksheet.row_dimensions[28].height = 68
+    for column in range(1, 8):
+        worksheet.column_dimensions[worksheet.cell(1, column).column_letter].width = 10
+    worksheet.sheet_view.topLeftCell = "A1"
+    worksheet.sheet_view.zoomScale = 115
+
+    scan = _scan(workbook, tmp_path / "tall-compact-view.xlsx")
+
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert finding.evidence.observed["estimated_content_height"] == 596.0
+    assert finding.evidence.observed["estimated_height_fit_zoom"] == 60
+    assert finding.evidence.observed["estimated_width_fit_zoom"] > 60
+    assert patch.after == {"top_left_cell": "A1", "zoom_scale": 55}
+
+
+def test_saved_view_offers_zoom_only_for_an_unshifted_frozen_pane(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(1, 29):
+        worksheet.cell(row, 1, f"Row {row}")
+        worksheet.row_dimensions[row].height = 18
+    worksheet.freeze_panes = "A2"
+    worksheet.sheet_view.zoomScale = 115
+
+    scan = _scan(workbook, tmp_path / "frozen-zoom.xlsx")
+
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert finding.evidence.details["pane_preserved"] is True
+    assert finding.evidence.details["zoom_only_with_frozen_pane"] is True
+    assert patch.after == {"zoom_scale": 65}
+
+
+def test_saved_view_reports_shifted_or_split_panes_without_a_patch(tmp_path: Path) -> None:
+    shifted = Workbook()
+    shifted_sheet = shifted.active
+    assert shifted_sheet is not None
+    for row in range(1, 29):
+        shifted_sheet.cell(row, 1, f"Row {row}")
+        shifted_sheet.row_dimensions[row].height = 18
+    shifted_sheet.freeze_panes = "A2"
+    assert shifted_sheet.sheet_view.pane is not None
+    shifted_sheet.sheet_view.pane.topLeftCell = "A20"
+    shifted_sheet.sheet_view.zoomScale = 115
+
+    shifted_scan = _scan(shifted, tmp_path / "shifted-frozen.xlsx")
+    shifted_finding = _findings(shifted_scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    assert shifted_finding.evidence.details["frozen_pane_offset"] is True
+    assert shifted_finding.patch_ids == []
+
+    split = Workbook()
+    split_sheet = split.active
+    assert split_sheet is not None
+    for row in range(1, 29):
+        split_sheet.cell(row, 1, f"Row {row}")
+        split_sheet.row_dimensions[row].height = 18
+    split_sheet.freeze_panes = "A2"
+    assert split_sheet.sheet_view.pane is not None
+    split_sheet.sheet_view.pane.state = "split"
+    split_sheet.sheet_view.zoomScale = 115
+
+    split_scan = _scan(split, tmp_path / "split-pane.xlsx")
+    split_finding = _findings(split_scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    assert split_finding.patch_ids == []
+
+
+def test_saved_view_includes_prior_row_height_patches_in_fit_estimate(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = (
+        "Long text in an automatic-height row that must wrap inside its border before view fitting"
+    )
+    worksheet["B1"] = "blocker"
+    worksheet.column_dimensions["A"].width = 8
+    for row in range(2, 29):
+        worksheet.cell(row, 1, f"Row {row}")
+        worksheet.row_dimensions[row].height = 18
+    worksheet.sheet_view.zoomScale = 115
+
+    scan = _scan(workbook, tmp_path / "planned-height-view.xlsx")
+
+    row_patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_ROW_HEIGHT)
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    view_patch = next(patch for patch in scan.patches if patch.kind == PatchKind.SET_SHEET_VIEW)
+    assert finding.evidence.details["planned_height_updates_included"] >= 1
+    assert finding.evidence.observed["estimated_content_height"] >= (
+        row_patch.after["height"] + 27 * 18
+    )
+    assert view_patch.after["zoom_scale"] <= 55
+
+
+def test_saved_view_includes_prior_column_width_patches_in_fit_estimate(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for row in range(1, 29):
+        worksheet.cell(row, 1, f"Row {row}")
+        worksheet.row_dimensions[row].height = 12
+    worksheet["J1"] = "联系电话"
+    worksheet["J2"] = 19_885_186_321
+    worksheet.column_dimensions["J"].width = 8
+    worksheet.sheet_view.zoomScale = 115
+
+    scan = _scan(workbook, tmp_path / "planned-width-view.xlsx")
+
+    width_patch = next(
+        patch
+        for patch in scan.patches
+        if patch.kind == PatchKind.SET_COLUMN_WIDTH and patch.after["column"] == "J"
+    )
+    finding = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")[0]
+    assert finding.evidence.details["planned_width_updates_included"] >= 1
+    assert finding.evidence.observed["estimated_content_width"] >= width_patch.after["width"]
+
+
+def test_saved_view_reports_extremely_wide_compact_sheet_without_unsafe_zoom_patch(
+    tmp_path: Path,
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    for column in range(1, 21):
+        cell = worksheet.cell(1, column, f"Header {column}")
+        worksheet.column_dimensions[cell.column_letter].width = 20
+    worksheet.sheet_view.topLeftCell = "A1"
+    worksheet.sheet_view.zoomScale = 200
+
+    scan = _scan(workbook, tmp_path / "extremely-wide-view.xlsx")
+
+    findings = _findings(scan, "WL020_SAVED_VIEW_OFF_CONTENT")
+    assert len(findings) == 1
+    assert findings[0].patch_ids == []
+    assert findings[0].evidence.details["fit_zoom_below_safe_floor"] is True
+    assert not any(patch.kind == PatchKind.SET_SHEET_VIEW for patch in scan.patches)
+
+
+def test_whitespace_only_tail_is_removed_without_deleting_custom_rows(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    thin = Side(style="thin")
+    full = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for row in range(1, 9):
+        for column in range(1, 14):
+            cell = worksheet.cell(row, column)
+            cell.border = full
+            if row <= 5:
+                cell.value = f"R{row}C{column}"
+    for row in range(9, 12):
+        worksheet.cell(row, 1, " ")
+        worksheet.row_dimensions[row].height = 30
+    source = tmp_path / "whitespace-tail.xlsx"
+    scan = _scan(workbook, source)
+
+    findings = _findings(scan, "WL021_WHITESPACE_ONLY_TAIL")
+    assert [finding.location for finding in findings] == ["A9:A11"]
+    patch = next(
+        patch for patch in scan.patches if patch.kind == PatchKind.REMOVE_WHITESPACE_TAIL_CELLS
+    )
+    assert patch.after["result_dimension"] == "A1:M8"
+
+    output = tmp_path / "whitespace-tail-fixed.xlsx"
+    apply_patch_plan(
+        source,
+        build_patch_plan(scan),
+        output,
+        selected_ids={patch.id},
+        accept_layout_risk=True,
+    )
+    repaired = load_workbook(output)
+    repaired_sheet = repaired.active
+    assert repaired_sheet is not None
+    assert repaired_sheet.calculate_dimension() == "A1:M8"
+    assert all((row, 1) not in repaired_sheet._cells for row in range(9, 12))
+    assert all(repaired_sheet.row_dimensions[row].height == 30 for row in range(9, 12))
+    repaired.close()
+    assert not _findings(scan_workbook(output), "WL021_WHITESPACE_ONLY_TAIL")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from workbooklens.models import Confidence, Severity
+from workbooklens.models import (
+    Confidence,
+    PatchKind,
+    PatchOperation,
+    PatchPlan,
+    PatchPrecondition,
+    PatchRisk,
+    Severity,
+    SheetSnapshot,
+)
 
 
 @pytest.mark.parametrize("value", [0.0, 0.25, 1.0])
@@ -19,3 +28,97 @@ def test_confidence_rejects_values_outside_unit_interval(value: float) -> None:
 
 def test_severity_values_are_stable() -> None:
     assert [value.value for value in Severity] == ["info", "warning", "error", "critical"]
+
+
+def _patch(
+    *,
+    patch_id: str = "patch-1",
+    kind: PatchKind = PatchKind.SET_FORMULA,
+    safe: bool = True,
+    risk: PatchRisk | None = None,
+    atomic_group: str | None = None,
+) -> PatchOperation:
+    payload: dict[str, object] = {
+        "id": patch_id,
+        "kind": kind,
+        "sheet": "Sheet1",
+        "cell": "A1",
+        "before": None,
+        "after": "=1+1",
+        "confidence": 0.99,
+        "safe": safe,
+        "description": "test patch",
+        "precondition": PatchPrecondition(
+            cell_fingerprint="cell-fingerprint",
+            layout_fingerprint="layout-fingerprint",
+        ),
+        "atomic_group": atomic_group,
+    }
+    if risk is not None:
+        payload["risk"] = risk
+    return PatchOperation.model_validate(payload)
+
+
+def test_non_layout_patch_defaults_to_safe_risk() -> None:
+    patch = _patch()
+    assert patch.risk == PatchRisk.SAFE
+    assert patch.safe_only_eligible
+
+
+def test_layout_patch_infers_review_risk_but_must_not_be_marked_safe() -> None:
+    patch = _patch(kind=PatchKind.SET_COLUMN_WIDTH, safe=False)
+    assert patch.risk == PatchRisk.LAYOUT_REVIEW
+    assert not patch.safe_only_eligible
+
+    with pytest.raises(ValidationError, match="safe=false"):
+        _patch(kind=PatchKind.SET_COLUMN_WIDTH, safe=True)
+
+
+def test_layout_patch_cannot_claim_safe_risk() -> None:
+    with pytest.raises(ValidationError, match="require risk='layout_review'"):
+        _patch(
+            kind=PatchKind.COPY_BORDER,
+            safe=False,
+            risk=PatchRisk.SAFE,
+        )
+
+
+def test_patch_plan_schema_two_round_trip_preserves_layout_metadata() -> None:
+    patch = _patch(
+        kind=PatchKind.SET_ROW_HEIGHT,
+        safe=False,
+        risk=PatchRisk.LAYOUT_REVIEW,
+        atomic_group="layout-group-1",
+    )
+    plan = PatchPlan(
+        tool_version="2.1.0",
+        source_name="input.xlsx",
+        source_sha256="abc123",
+        patches=[patch],
+    )
+
+    restored = PatchPlan.model_validate_json(plan.model_dump_json())
+
+    assert restored.schema_version == 2
+    assert restored.patches[0].atomic_group == "layout-group-1"
+    assert restored.patches[0].risk == PatchRisk.LAYOUT_REVIEW
+    assert restored.patches[0].precondition.layout_fingerprint == "layout-fingerprint"
+
+
+def test_legacy_sheet_snapshot_payload_loads_with_layout_defaults() -> None:
+    snapshot = SheetSnapshot.model_validate(
+        {
+            "name": "Sheet1",
+            "index": 0,
+            "state": "visible",
+            "max_row": 1,
+            "max_column": 1,
+        }
+    )
+
+    assert snapshot.declared_dimension is None
+    assert snapshot.content_dimension is None
+    assert snapshot.row_heights == {}
+    assert snapshot.column_widths == {}
+    assert snapshot.view_top_left_cell is None
+    assert snapshot.view_zoom_scale is None

--- a/tests/unit/test_ooxml_patch_selection.py
+++ b/tests/unit/test_ooxml_patch_selection.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from workbooklens.exceptions import UsageError
+from workbooklens.models import (
+    PatchKind,
+    PatchOperation,
+    PatchPlan,
+    PatchPrecondition,
+    PatchRisk,
+)
+from workbooklens.repair.ooxml_patch import _select_patches
+
+
+def _patch(
+    patch_id: str,
+    *,
+    kind: PatchKind = PatchKind.SET_FORMULA,
+    safe: bool = True,
+    risk: PatchRisk = PatchRisk.SAFE,
+    confidence: float = 0.99,
+    atomic_group: str | None = None,
+    after: object | None = None,
+) -> PatchOperation:
+    patch_after = after
+    if patch_after is None:
+        patch_after = 16.0 if kind == PatchKind.SET_COLUMN_WIDTH else "=1+1"
+    return PatchOperation(
+        id=patch_id,
+        kind=kind,
+        sheet="Sheet1",
+        cell=f"A{patch_id.removeprefix('p')}",
+        after=patch_after,
+        confidence=confidence,
+        safe=safe,
+        risk=risk,
+        description="selection test patch",
+        precondition=PatchPrecondition(cell_fingerprint=f"fingerprint-{patch_id}"),
+        atomic_group=atomic_group,
+    )
+
+
+def _plan(*patches: PatchOperation) -> PatchPlan:
+    return PatchPlan(
+        tool_version="2.1.0",
+        source_name="input.xlsx",
+        source_sha256="abc123",
+        patches=list(patches),
+    )
+
+
+def test_low_level_explicit_selection_rejects_incomplete_atomic_group() -> None:
+    plan = _plan(
+        _patch("p1", atomic_group="g1"),
+        _patch("p2", atomic_group="g1"),
+    )
+
+    with pytest.raises(UsageError, match="Atomic patch groups must be selected in full"):
+        _select_patches(plan, {"p1"}, safe_only=False)
+
+
+def test_low_level_layout_acceptance_still_rejects_low_confidence() -> None:
+    plan = _plan(
+        _patch(
+            "p1",
+            kind=PatchKind.SET_COLUMN_WIDTH,
+            safe=False,
+            risk=PatchRisk.LAYOUT_REVIEW,
+            confidence=0.94,
+        )
+    )
+
+    with pytest.raises(UsageError, match="authorized repair risk boundary"):
+        _select_patches(
+            plan,
+            {"p1"},
+            safe_only=False,
+            accept_layout_risk=True,
+        )

--- a/tests/unit/test_repair_engine.py
+++ b/tests/unit/test_repair_engine.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import workbooklens.repair.engine as engine
+from workbooklens.exceptions import PatchValidationError, UsageError
+from workbooklens.models import (
+    Evidence,
+    Finding,
+    PatchKind,
+    PatchOperation,
+    PatchPlan,
+    PatchPrecondition,
+    PatchRisk,
+    Severity,
+)
+
+
+def _layout_plan() -> PatchPlan:
+    patches = [
+        PatchOperation(
+            id=patch_id,
+            kind=PatchKind.SET_COLUMN_WIDTH,
+            sheet="Sheet1",
+            cell=cell,
+            before=8.43,
+            after=16.0,
+            confidence=0.99,
+            safe=False,
+            risk=PatchRisk.LAYOUT_REVIEW,
+            description="test layout patch",
+            precondition=PatchPrecondition(cell_fingerprint=f"fingerprint-{patch_id}"),
+            atomic_group="layout-group",
+        )
+        for patch_id, cell in (("p1", "A1"), ("p2", "B1"))
+    ]
+    return PatchPlan(
+        tool_version="2.1.0",
+        source_name="input.xlsx",
+        source_sha256="abc123",
+        patches=patches,
+    )
+
+
+def test_apply_resolves_atomic_group_before_calling_low_level_patcher(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan = _layout_plan()
+    scan = SimpleNamespace(findings=[])
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(engine, "scan_workbook", lambda *args, **kwargs: scan)
+    monkeypatch.setattr(engine, "build_patch_plan", lambda _scan: plan)
+
+    def fake_patch(*args: Any, **kwargs: Any) -> tuple[SimpleNamespace, list[PatchOperation]]:
+        captured.update(kwargs)
+        selected_ids = kwargs["selected_ids"]
+        selected = [patch for patch in plan.patches if patch.id in selected_ids]
+        low_level = SimpleNamespace(
+            source_sha256="source-hash",
+            output_sha256="output-hash",
+            changes=[],
+            formula_changed=False,
+        )
+        return low_level, selected
+
+    monkeypatch.setattr(engine, "patch_ooxml_package", fake_patch)
+
+    result = engine.apply_patch_plan(
+        tmp_path / "input.xlsx",
+        plan,
+        tmp_path / "output.xlsx",
+        selected_ids=["p1"],
+        accept_layout_risk=True,
+    )
+
+    assert captured["selected_ids"] == {"p1", "p2"}
+    assert captured["safe_only"] is False
+    assert captured["accept_layout_risk"] is True
+    assert result.applied_patch_ids == ["p1", "p2"]
+
+
+def test_apply_rejects_selection_before_scanning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan = _layout_plan()
+    scanned = False
+
+    def fake_scan(*args: Any, **kwargs: Any) -> None:
+        nonlocal scanned
+        scanned = True
+
+    monkeypatch.setattr(engine, "scan_workbook", fake_scan)
+
+    with pytest.raises(UsageError, match="Unknown patch IDs"):
+        engine.apply_patch_plan(
+            tmp_path / "input.xlsx",
+            plan,
+            tmp_path / "output.xlsx",
+            selected_ids=["missing"],
+        )
+
+    assert not scanned
+
+
+def test_apply_rejects_targeted_finding_that_changes_identity_but_remains(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plan = _layout_plan()
+
+    def finding(identifier: str) -> Finding:
+        return Finding(
+            id=identifier,
+            rule_id="WL016_TEXT_DISPLAY_RISK",
+            title="display risk",
+            explanation="test",
+            severity=Severity.WARNING,
+            confidence=0.99,
+            workbook="input.xlsx",
+            sheet="Sheet1",
+            location="A1",
+            evidence=Evidence(summary="test"),
+            expected="visible text",
+            suggested_action="test",
+            safe_patch_available=False,
+            patch_ids=["p1", "p2"] if identifier == "before-id" else [],
+        )
+
+    scans = iter(
+        [
+            SimpleNamespace(findings=[finding("before-id")]),
+            SimpleNamespace(findings=[finding("after-id")]),
+        ]
+    )
+    monkeypatch.setattr(engine, "scan_workbook", lambda *args, **kwargs: next(scans))
+    monkeypatch.setattr(engine, "build_patch_plan", lambda _scan: plan)
+
+    def fake_patch(*args: Any, **kwargs: Any) -> tuple[SimpleNamespace, list[PatchOperation]]:
+        output = args[2]
+        output.write_bytes(b"candidate")
+        low_level = SimpleNamespace(
+            source_sha256="source-hash",
+            output_sha256="output-hash",
+            changes=[],
+            formula_changed=False,
+        )
+        return low_level, plan.patches
+
+    monkeypatch.setattr(engine, "patch_ooxml_package", fake_patch)
+    output = tmp_path / "output.xlsx"
+
+    with pytest.raises(PatchValidationError, match="did not resolve targeted findings"):
+        engine.apply_patch_plan(
+            tmp_path / "input.xlsx",
+            plan,
+            output,
+            selected_ids=["p1"],
+            accept_layout_risk=True,
+        )
+
+    assert not output.exists()

--- a/tests/unit/test_repair_planning.py
+++ b/tests/unit/test_repair_planning.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from workbooklens.exceptions import UsageError
+from workbooklens.models import (
+    PatchKind,
+    PatchOperation,
+    PatchPlan,
+    PatchPrecondition,
+    PatchRisk,
+)
+from workbooklens.repair.planning import load_patch_plan, resolve_patch_selection
+
+
+def _patch(
+    patch_id: str,
+    *,
+    kind: PatchKind = PatchKind.SET_FORMULA,
+    safe: bool = True,
+    risk: PatchRisk = PatchRisk.SAFE,
+    confidence: float = 0.99,
+    atomic_group: str | None = None,
+) -> PatchOperation:
+    return PatchOperation(
+        id=patch_id,
+        kind=kind,
+        sheet="Sheet1",
+        cell=f"A{patch_id.removeprefix('p') or '1'}",
+        before=None,
+        after="=1+1",
+        confidence=confidence,
+        safe=safe,
+        risk=risk,
+        description="test patch",
+        precondition=PatchPrecondition(cell_fingerprint=f"fingerprint-{patch_id}"),
+        atomic_group=atomic_group,
+    )
+
+
+def _plan(*patches: PatchOperation) -> PatchPlan:
+    return PatchPlan(
+        tool_version="2.1.0",
+        source_name="input.xlsx",
+        source_sha256="abc123",
+        patches=list(patches),
+    )
+
+
+def _layout_patch(patch_id: str, *, atomic_group: str | None = None) -> PatchOperation:
+    return _patch(
+        patch_id,
+        kind=PatchKind.SET_COLUMN_WIDTH,
+        safe=False,
+        risk=PatchRisk.LAYOUT_REVIEW,
+        atomic_group=atomic_group,
+    )
+
+
+def test_explicit_selection_expands_the_entire_atomic_group() -> None:
+    plan = _plan(
+        _patch("p1", atomic_group="g1"),
+        _patch("p2", atomic_group="g1"),
+        _patch("p3"),
+    )
+
+    assert resolve_patch_selection(plan, ["p1"]) == {"p1", "p2"}
+
+
+def test_explicit_selection_expands_multiple_groups_and_keeps_ungrouped_patches() -> None:
+    plan = _plan(
+        _patch("p1", atomic_group="g1"),
+        _patch("p2", atomic_group="g1"),
+        _patch("p3", atomic_group="g2"),
+        _patch("p4", atomic_group="g2"),
+        _patch("p5"),
+    )
+
+    assert resolve_patch_selection(plan, ["p1", "p3", "p5"]) == {
+        "p1",
+        "p2",
+        "p3",
+        "p4",
+        "p5",
+    }
+
+
+def test_safe_only_excludes_layout_review_patches() -> None:
+    plan = _plan(_patch("p1"), _layout_patch("p2"))
+
+    assert resolve_patch_selection(plan, safe_only=True) == {"p1"}
+
+
+def test_safe_only_skips_a_whole_atomic_group_with_a_review_member() -> None:
+    plan = _plan(
+        _patch("p1", atomic_group="mixed"),
+        _layout_patch("p2", atomic_group="mixed"),
+        _patch("p3"),
+    )
+
+    assert resolve_patch_selection(plan, safe_only=True) == {"p3"}
+
+
+def test_layout_review_requires_explicit_acceptance_and_then_expands_group() -> None:
+    plan = _plan(
+        _layout_patch("p1", atomic_group="layout"),
+        _layout_patch("p2", atomic_group="layout"),
+    )
+
+    with pytest.raises(UsageError, match="--accept-layout-risk"):
+        resolve_patch_selection(plan, ["p1"])
+
+    assert resolve_patch_selection(
+        plan,
+        ["p1"],
+        accept_layout_risk=True,
+    ) == {"p1", "p2"}
+
+
+def test_layout_acceptance_does_not_enable_other_unsafe_or_low_confidence_patches() -> None:
+    unsafe_plan = _plan(_patch("p1", safe=False))
+    with pytest.raises(UsageError, match="refuses unsafe"):
+        resolve_patch_selection(unsafe_plan, ["p1"], accept_layout_risk=True)
+
+    low_confidence_plan = _plan(_patch("p2", confidence=0.94))
+    with pytest.raises(UsageError, match=r"0\.95 confidence"):
+        resolve_patch_selection(low_confidence_plan, ["p2"], accept_layout_risk=True)
+
+
+def test_selection_rejects_duplicate_unknown_empty_and_mutually_exclusive_inputs() -> None:
+    plan = _plan(_patch("p1"))
+
+    with pytest.raises(UsageError, match="Duplicate --patch-id"):
+        resolve_patch_selection(plan, ["p1", "p1"])
+    with pytest.raises(UsageError, match="Unknown patch IDs"):
+        resolve_patch_selection(plan, ["missing"])
+    with pytest.raises(UsageError, match="Select at least one"):
+        resolve_patch_selection(plan)
+    with pytest.raises(UsageError, match="mutually exclusive"):
+        resolve_patch_selection(plan, ["p1"], safe_only=True)
+    with pytest.raises(UsageError, match="mutually exclusive"):
+        resolve_patch_selection(plan, safe_only=True, accept_layout_risk=True)
+
+
+def test_selection_rejects_duplicate_plan_ids() -> None:
+    plan = _plan(_patch("p1"), _patch("p2"))
+    plan.patches[1].id = "p1"
+
+    with pytest.raises(UsageError, match="duplicate patch IDs"):
+        resolve_patch_selection(plan, safe_only=True)
+
+
+def test_safe_only_rejects_an_empty_eligible_selection() -> None:
+    plan = _plan(_layout_patch("p1"))
+
+    with pytest.raises(UsageError, match="No eligible patches"):
+        resolve_patch_selection(plan, safe_only=True)
+
+
+def test_load_patch_plan_clearly_rejects_schema_one(tmp_path: Path) -> None:
+    path = tmp_path / "schema-one.json"
+    path.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+
+    with pytest.raises(UsageError, match="schema version 2"):
+        load_patch_plan(path)

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -4,10 +4,13 @@ from pathlib import Path
 
 import pytest
 from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill, Protection
+from openpyxl.formula.tokenizer import TokenizerError
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Protection, Side
 
+import workbooklens.rules.builtin as builtin_rules
 from workbooklens.demo.workflow import generate_demo_workbook
-from workbooklens.models import PatchKind
+from workbooklens.models import PatchKind, PatchRisk
+from workbooklens.rules.builtin import BUILTIN_RULES
 from workbooklens.scanner import ScanResult, scan_workbook
 
 
@@ -20,7 +23,7 @@ def demo_scan(tmp_path_factory: pytest.TempPathFactory) -> ScanResult:
     return scan_workbook(path, config=config)
 
 
-def test_demo_exercises_fourteen_rules_and_generated_patch_kinds(demo_scan: ScanResult) -> None:
+def test_demo_exercises_fifteen_rules_and_generated_patch_kinds(demo_scan: ScanResult) -> None:
     rule_ids = {finding.rule_id for finding in demo_scan.findings}
     assert rule_ids == {
         "WL001_BROKEN_REFERENCE",
@@ -37,9 +40,24 @@ def test_demo_exercises_fourteen_rules_and_generated_patch_kinds(demo_scan: Scan
         "WL013_BROKEN_DEFINED_NAME",
         "WL014_MERGED_CELL_IN_DATA_REGION",
         "WL015_INCONSISTENT_DATA_VALIDATION",
+        "WL016_TEXT_DISPLAY_RISK",
     }
-    assert {patch.kind for patch in demo_scan.patches} == set(PatchKind) - {PatchKind.EXTEND_SUM}
-    assert all(patch.safe and float(patch.confidence) >= 0.95 for patch in demo_scan.patches)
+    assert {patch.kind for patch in demo_scan.patches} == {
+        PatchKind.SET_FORMULA,
+        PatchKind.SET_NUMERIC,
+        PatchKind.COPY_STYLE,
+        PatchKind.CREATE_FORMULA,
+        PatchKind.SET_ROW_HEIGHT,
+        PatchKind.SET_WRAP_TEXT,
+    }
+    assert all(
+        patch.safe_only_eligible for patch in demo_scan.patches if patch.risk == PatchRisk.SAFE
+    )
+    assert all(
+        not patch.safe and patch.risk == PatchRisk.LAYOUT_REVIEW
+        for patch in demo_scan.patches
+        if patch.kind in {PatchKind.SET_ROW_HEIGHT, PatchKind.SET_WRAP_TEXT}
+    )
 
 
 def test_formula_pattern_outlier_rule_and_safe_proposal(tmp_path: Path) -> None:
@@ -672,6 +690,129 @@ def test_style_outlier_with_different_number_format_has_no_patch(tmp_path: Path)
     )
 
 
+@pytest.mark.parametrize("missing_side", ["left", "right"])
+def test_single_sided_shared_border_is_visually_equivalent(
+    tmp_path: Path, missing_side: str
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Context", "Amount", "Context"])
+    side = Side(style="thin", color="336699")
+    grid = Border(left=side, right=side, top=side, bottom=side)
+    for row in range(2, 22):
+        worksheet.append([f"L{row}", row * 100, f"R{row}"])
+        for cell in worksheet[row]:
+            cell.border = grid
+    target = worksheet["B10"]
+    target.border = Border(
+        left=None if missing_side == "left" else side,
+        right=None if missing_side == "right" else side,
+        top=side,
+        bottom=side,
+    )
+    path = tmp_path / f"shared-border-{missing_side}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert not any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "B10"
+        for finding in scan.findings
+    )
+
+
+@pytest.mark.parametrize("component", ["font", "fill", "alignment", "number_format", "border"])
+def test_material_visual_style_difference_remains_an_outlier(
+    tmp_path: Path, component: str
+) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Context", "Amount"])
+    side = Side(style="thin", color="336699")
+    grid = Border(left=side, right=side, top=side, bottom=side)
+    for row in range(2, 22):
+        worksheet.append([f"R{row}", row * 100])
+        for cell in worksheet[row]:
+            cell.border = grid
+    target = worksheet["B10"]
+    if component == "font":
+        target.font = Font(bold=True)
+    elif component == "fill":
+        target.fill = PatternFill("solid", fgColor="FFF2CC")
+    elif component == "alignment":
+        target.alignment = Alignment(horizontal="right")
+    elif component == "number_format":
+        target.number_format = "0.00"
+    else:
+        target.border = Border(right=side, top=side, bottom=side)
+        worksheet["A10"].border = Border(left=side, top=side, bottom=side)
+    path = tmp_path / f"material-style-{component}.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+    assert any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "B10"
+        for finding in scan.findings
+    )
+
+
+def test_row_local_sum_does_not_hide_a_style_outlier(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "A", "B", "C", "Row total"])
+    for row in range(2, 22):
+        worksheet.append([f"R{row}", row, row + 1, row + 2, f"=SUM(B{row}:D{row})+$A$1"])
+    worksheet["C10"].font = Font(bold=True)
+    path = tmp_path / "row-local-sum-style-outlier.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+
+    assert any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "C10"
+        for finding in scan.findings
+    )
+
+
+def test_unlabelled_cross_row_sum_still_marks_a_summary_row(tmp_path: Path) -> None:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet.append(["Item", "Amount"])
+    for row in range(2, 22):
+        worksheet.append([f"R{row}", row * 10])
+    worksheet.append(["Result", "=SUM(B2:B21)"])
+    worksheet["B22"].font = Font(bold=True)
+    path = tmp_path / "unlabelled-summary-row.xlsx"
+    workbook.save(path)
+    workbook.close()
+
+    scan = scan_workbook(path)
+
+    assert not any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location == "B22"
+        for finding in scan.findings
+    )
+
+
+@pytest.mark.parametrize("error_type", [ValueError, IndexError, TokenizerError])
+def test_malformed_aggregate_formula_is_handled_conservatively(
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[Exception],
+) -> None:
+    def reject_formula(_formula: str):
+        raise error_type("malformed aggregate formula")
+
+    monkeypatch.setattr(builtin_rules, "Tokenizer", reject_formula)
+
+    assert builtin_rules._aggregate_formula_spans_other_rows("=SUM(A1:A2)", 3)
+
+
 def test_pivot_button_only_difference_is_not_a_visual_style_outlier(tmp_path: Path) -> None:
     workbook = Workbook()
     worksheet = workbook.active
@@ -718,7 +859,9 @@ def test_multiple_style_outliers_are_findings_only(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("label", ["Grand Total", "Summary", "总金额", "累计金额", "期末余额"])
-def test_summary_row_style_outliers_are_never_auto_copied(tmp_path: Path, label: str) -> None:
+def test_summary_row_style_outliers_are_not_reported_or_auto_copied(
+    tmp_path: Path, label: str
+) -> None:
     workbook = Workbook()
     worksheet = workbook.active
     assert worksheet is not None
@@ -733,6 +876,10 @@ def test_summary_row_style_outliers_are_never_auto_copied(tmp_path: Path, label:
     workbook.close()
 
     scan = scan_workbook(path)
+    assert not any(
+        finding.rule_id == "WL007_STYLE_OUTLIER" and finding.location in {"A22", "B22"}
+        for finding in scan.findings
+    )
     assert not any(
         patch.kind == PatchKind.COPY_STYLE and patch.cell in {"A22", "B22"}
         for patch in scan.patches
@@ -841,7 +988,7 @@ def test_visually_marked_blank_formula_gap_is_findings_only(tmp_path: Path) -> N
     assert not any(patch.cell == "B10" for patch in scan.patches)
 
 
-def test_summary_label_outside_inferred_region_blocks_numeric_and_style_patches(
+def test_summary_label_outside_inferred_region_suppresses_style_finding_and_patches(
     tmp_path: Path,
 ) -> None:
     workbook = Workbook()
@@ -862,7 +1009,7 @@ def test_summary_label_outside_inferred_region_blocks_numeric_and_style_patches(
     scan = scan_workbook(path)
     findings = {(finding.rule_id, finding.location) for finding in scan.findings}
     assert ("WL006_NUMERIC_TEXT", "D10") in findings
-    assert ("WL007_STYLE_OUTLIER", "D10") in findings
+    assert ("WL007_STYLE_OUTLIER", "D10") not in findings
     assert not any(patch.cell == "D10" for patch in scan.patches)
 
 
@@ -1236,22 +1383,8 @@ def test_hidden_literal_is_never_replaced(tmp_path: Path) -> None:
     assert not any(patch.cell == "B10" for patch in scan.patches)
 
 
-def test_all_fifteen_builtin_rule_ids_are_stable(demo_scan: ScanResult, tmp_path: Path) -> None:
-    workbook = Workbook()
-    worksheet = workbook.active
-    assert worksheet is not None
-    for column in range(1, 21):
-        worksheet.cell(1, column, column)
-        worksheet.cell(2, column, f"={worksheet.cell(1, column).coordinate}*2")
-    worksheet["J2"] = "=J1*3"
-    path = tmp_path / "rule-two.xlsx"
-    workbook.save(path)
-    workbook.close()
-    second_scan = scan_workbook(path)
-    all_ids = {finding.rule_id for finding in demo_scan.findings} | {
-        finding.rule_id for finding in second_scan.findings
-    }
-    assert all_ids == {
+def test_all_twenty_one_builtin_rule_ids_are_stable() -> None:
+    assert {rule.rule_id for rule in BUILTIN_RULES} == {
         f"WL{number:03d}_{suffix}"
         for number, suffix in enumerate(
             [
@@ -1270,6 +1403,12 @@ def test_all_fifteen_builtin_rule_ids_are_stable(demo_scan: ScanResult, tmp_path
                 "BROKEN_DEFINED_NAME",
                 "MERGED_CELL_IN_DATA_REGION",
                 "INCONSISTENT_DATA_VALIDATION",
+                "TEXT_DISPLAY_RISK",
+                "BORDER_EDGE_INCONSISTENCY",
+                "USED_RANGE_INFLATION",
+                "IDENTIFIER_SCIENTIFIC_NOTATION",
+                "SAVED_VIEW_OFF_CONTENT",
+                "WHITESPACE_ONLY_TAIL",
             ],
             start=1,
         )

--- a/tests/unit/test_scanner_patch_normalization.py
+++ b/tests/unit/test_scanner_patch_normalization.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from openpyxl import Workbook
+
+from workbooklens.models import (
+    Evidence,
+    Finding,
+    PatchKind,
+    PatchOperation,
+    PatchPrecondition,
+    PatchRisk,
+    Severity,
+)
+from workbooklens.rules import RuleContext, RuleRegistry, RuleResult, WorkbookRule
+from workbooklens.scanner import scan_workbook
+from workbooklens.snapshot import cell_fingerprint
+
+
+class _PatchRule(WorkbookRule):
+    title = "test"
+
+    def __init__(self, rule_id: str, *, description: str, emit_patch: bool = True) -> None:
+        self.rule_id = rule_id
+        self.description = description
+        self.emit_patch = emit_patch
+
+    def run(self, context: RuleContext) -> RuleResult:
+        worksheet = context.workbook.active
+        cell = worksheet["A1"]
+        patch = PatchOperation(
+            id="patch-shared-identity",
+            kind=PatchKind.SET_NUMERIC,
+            sheet=worksheet.title,
+            cell="A1",
+            before=1,
+            after=2,
+            confidence=0.99,
+            safe=True,
+            risk=PatchRisk.SAFE,
+            description=self.description,
+            precondition=PatchPrecondition(
+                cell_fingerprint=cell_fingerprint(cell),
+                expected_value=1,
+                expected_style_id=cell.style_id,
+            ),
+        )
+        finding = Finding(
+            id=f"finding-{self.rule_id}",
+            rule_id=self.rule_id,
+            title=self.title,
+            explanation="test",
+            severity=Severity.WARNING,
+            confidence=0.99,
+            workbook=context.path.name,
+            sheet=worksheet.title,
+            location="A1",
+            evidence=Evidence(summary="test"),
+            expected="test",
+            suggested_action="test",
+            safe_patch_available=True,
+            patch_ids=[patch.id],
+        )
+        return RuleResult(findings=[finding], patches=[patch] if self.emit_patch else [])
+
+
+def _source(tmp_path: Path) -> Path:
+    path = tmp_path / "scanner-normalization.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    worksheet["A1"] = 1
+    workbook.save(path)
+    workbook.close()
+    return path
+
+
+def test_identical_duplicate_patch_payload_is_deduplicated(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    registry = RuleRegistry(
+        [
+            _PatchRule("TEST_A", description="same"),
+            _PatchRule("TEST_B", description="same"),
+        ]
+    )
+
+    scan = scan_workbook(source, registry=registry)
+
+    assert [patch.id for patch in scan.patches] == ["patch-shared-identity"]
+    assert all(finding.patch_ids == ["patch-shared-identity"] for finding in scan.findings)
+
+
+def test_conflicting_duplicate_patch_payload_is_rejected(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    registry = RuleRegistry(
+        [
+            _PatchRule("TEST_A", description="first"),
+            _PatchRule("TEST_B", description="second"),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="Conflicting patch identity"):
+        scan_workbook(source, registry=registry)
+
+
+def test_finding_cannot_reference_a_missing_patch(tmp_path: Path) -> None:
+    source = _source(tmp_path)
+    registry = RuleRegistry([_PatchRule("TEST_A", description="missing", emit_patch=False)])
+
+    with pytest.raises(RuntimeError, match="references missing patches"):
+        scan_workbook(source, registry=registry)

--- a/tests/unit/test_snapshot_fingerprints.py
+++ b/tests/unit/test_snapshot_fingerprints.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from copy import copy
+
+from openpyxl import Workbook
+from openpyxl.styles import Border, Font, Side
+from openpyxl.utils.indexed_list import IndexedList
+
+from workbooklens.snapshot import cell_fingerprint
+
+
+def _styled_formula_workbook() -> tuple[Workbook, object]:
+    workbook = Workbook()
+    worksheet = workbook.active
+    assert worksheet is not None
+    cell = worksheet["B2"]
+    cell.value = "=ROUND(1.25*2,2)"
+    cell.number_format = '"$"#,##0.00'
+    cell.font = Font(name="Arial", bold=True)
+    cell.border = Border()
+    return workbook, cell
+
+
+def test_cell_fingerprint_ignores_workbook_local_style_table_index() -> None:
+    workbook, cell = _styled_formula_workbook()
+    try:
+        before_style_id = cell.style_id
+        before = cell_fingerprint(cell)
+
+        styles = list(workbook._cell_styles)
+        dummy_style = copy(styles[0])
+        dummy_style.fontId = 999
+        workbook._cell_styles = IndexedList([dummy_style, *styles])
+
+        assert cell.style_id != before_style_id
+        assert cell_fingerprint(cell) == before
+    finally:
+        workbook.close()
+
+
+def test_cell_fingerprint_still_detects_effective_border_change() -> None:
+    workbook, cell = _styled_formula_workbook()
+    try:
+        before = cell_fingerprint(cell)
+        cell.border = Border(top=Side(style="dashed"))
+        assert cell_fingerprint(cell) != before
+    finally:
+        workbook.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1194,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "workbooklens"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What changed

- Add deterministic layout and display analysis for clipped text, numeric identifiers, row heights, column widths, shared borders, saved views, and formatting/whitespace tails.
- Add fail-closed direct OOXML layout repair with source-bound preconditions, atomic groups, semantic validation, and rescan verification.
- Fix WL007 row-local aggregate handling, malformed frozen-pane bounds, duplicate style-ID validation, and valid Default workbook content types.
- Harden the local Web UI before multipart parsing with loopback Host checks, Origin/Referer checks, CSRF cookies, Content-Length validation, and streaming body limits.
- Update 2.2.0 documentation, local wheel installation instructions, release checksums, CI smoke tests, and release metadata.

## Why

Real-world workbooks exposed clipped text, incomplete shared borders, incorrect viewport sizing, style-ID renumbering, and multipart requests that were rejected only after parsing. This release addresses those cases while preserving workbook values, formulas, types, and number formats.

## Validation

- 403 tests passed; total coverage 82.16%
- Ruff format/check passed
- mypy passed on 37 source files
- uv lock --check passed
- locked runtime audit: no known vulnerabilities
- final mixed stress workbook: 93 findings / 46 patches before, 0 findings / 0 patches after
- cell values, formulas, data types, and number formats: 0 semantic changes
- wheel/sdist passed strict Twine and release allowlist checks
- fresh Python 3.12 wheel install passed version/help/demo and local Web upload smoke tests

